### PR TITLE
Fix issue 33: isobar re-selection following load of grid without isobar data

### DIFF
--- a/src/MapDrawer.h
+++ b/src/MapDrawer.h
@@ -75,6 +75,8 @@ friend class Terrain;	// TODO (or not) getters setters
 						GriddedPlotter *plotter,
 						Projection *proj,
 						QList<POI*> lspois );
+
+        void	initGraphicsParameters  ();
 					
 	private:
 		QPixmap     *imgEarth;   // images précalculées pour accélérer l'affichage
@@ -150,7 +152,7 @@ friend class Terrain;	// TODO (or not) getters setters
 		QPen	riversPen;
 
 		void	updateGraphicsParameters();
-		void	initGraphicsParameters  ();
+
 		void    addUsedDataCenterModel (const DataCode &dtc, GriddedPlotter *plotter);
 		
 		void    draw_MeteoData_Gridded 

--- a/src/Terrain.cpp
+++ b/src/Terrain.cpp
@@ -743,6 +743,9 @@ FileDataType Terrain::loadMeteoDataFile (QString fileName, bool zoom)
     if (zoom) {
         zoomOnFileZone();    // Zoom sur la zone couverte par le fichier GRIB
     }
+
+    drawer -> initGraphicsParameters(); // reset the map drawer to app settings
+
     update();
 
 	bool cancelled = ! taskProgress->continueDownload;


### PR DESCRIPTION
Force MapDrawer to reload app settings following load of new grid data (previously only pulled this in on construction).