### PR TITLE
Implement travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: cpp
+
+matrix:
+  include:
+    - dist: trusty
+      compiler: gcc
+    - os: osx
+      compiler: clang
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade; fi
+# Homebrew upgrade disabled to save time.
+
+install:
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install build-essential git cmake qt5-default libpng-dev libopenjpeg-dev libnova-dev libproj-dev zlib1g-dev libbz2-dev; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap indilib/indi; brew install git cmake libnova openjpeg libpng qt5; export PATH="/usr/local/opt/qt5/bin:$PATH";  echo 'export PATH="/usr/local/opt/qt5/bin:$PATH"' >> ~/.bash_profile; fi
+
+script:
+    - mkdir build && cd build
+    - cmake ..
+    - make -s
+
+notifications:
+    email: false
+    
+git:
+    depth: 10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ find_package(Qt5Xml CONFIG REQUIRED)
 include_directories(${Qt5Xml_INCLUDE_DIRS})
 
 find_library(LIBNOVA_LIBRARY
-     NAMES "libnova.so"
+     NAMES "libnova.a" "libnova.so"
      PATHS
      $ENV{EXTERNLIBS}/libnova
      ~/Library/Frameworks
@@ -75,7 +75,7 @@ include_directories(${LIBNOVA_INCLUDE_DIR})
 
 #find_package(OpenJPEG REQUIRED)
 find_library(OPENJPEG_LIBRARIES
-     NAMES "libopenjp2.a" "libopenjp2.so"
+     NAMES "libopenjp2.a" "libopenjp2.so" "libopenjpeg.so.2"
      PATHS
      $ENV{EXTERNLIBS}/openjpeg
      ~/Library/Frameworks

--- a/README.cmake.md
+++ b/README.cmake.md
@@ -5,7 +5,7 @@
 ### macOS
 
 - Install [Homebrew](https://brew.sh)
-- Install the requred packages: `brew git cmake install libnova openjpeg libpng qt5`
+- Install the requred packages: `brew tap indilib/indi; brew install git cmake libnova openjpeg libpng qt5`
 
 ### Linux
 

--- a/README.cmake.md
+++ b/README.cmake.md
@@ -10,7 +10,8 @@
 ### Linux
 
 - Install the required libraries
-  - Ubuntu: `sudo apt-get install build-essential git cmake qt5-default libpng-dev libopenjp2-7-dev libnova-dev libproj-dev zlib1g-dev libbz2-dev`
+  - Ubuntu (recent editions): `sudo apt-get install build-essential git cmake qt5-default libpng-dev libopenjp2-7-dev libnova-dev libproj-dev zlib1g-dev libbz2-dev`
+  - Ubuntu Trusty: `sudo apt-get install build-essential git cmake qt5-default libpng-dev libopenjpeg-dev libnova-dev libproj-dev zlib1g-dev libbz2-dev`
 
 ### Windows
 


### PR DESCRIPTION
also improves the cmake build system to support Ubuntu Trusty and fixes the macOS build and build instructions

- You need to create an account for `opengribs` at https://travis-ci.org and link it with the github repository to enable all the future PRs and commits to be built automatically.
- TODO: In the future, when the scriptable build process integrates packaging, tagged build artefacts can be automatically uploaded to the github releases (Especially useful for macOS in XyGribs case).