### PR TITLE
Percent values

### DIFF
--- a/src/DataColors.cpp
+++ b/src/DataColors.cpp
@@ -123,6 +123,7 @@ QRgb  DataColors::getCloudColor (double v, bool smooth) {
     int tr;
     if (isCloudsColorModeWhite) {
 		rgb = colors_CloudsWhite.getColor (v, smooth);
+		v = Util::inRange(v, 0., 100.);
 		tr = (int)(2.5*v);
 	}
 	else {

--- a/src/DataPointInfo.cpp
+++ b/src/DataPointInfo.cpp
@@ -95,33 +95,32 @@ DataPointInfo::DataPointInfo (
 	//----------------------------------------
 	// Cloud : total cover
 	//----------------------------------------
-	cloudTotal = reader==NULL ? GRIB_NOTDEF
-			: reader->getDateInterpolatedValue (DataCode(GRB_CLOUD_TOT,LV_ATMOS_ALL,0), x,y,date);
+	// wgrib2 normalisation can return values < 0 or > 100 %
+	cloudTotal = getPercentValue(DataCode(GRB_CLOUD_TOT,LV_ATMOS_ALL,0));
+
 	//----------------------------------------
 	// Cloud : layers
 	//----------------------------------------
-	cloudLow = reader==NULL ? GRIB_NOTDEF
-			: reader->getDateInterpolatedValue (DataCode(GRB_CLOUD_TOT,LV_CLOUD_LOW_LAYER,0), x,y,date);
-	cloudMid = reader==NULL ? GRIB_NOTDEF
-			: reader->getDateInterpolatedValue (DataCode(GRB_CLOUD_TOT,LV_CLOUD_MID_LAYER,0), x,y,date);
-	cloudHigh = reader==NULL ? GRIB_NOTDEF
-			: reader->getDateInterpolatedValue (DataCode(GRB_CLOUD_TOT,LV_CLOUD_HIG_LAYER,0), x,y,date);
+	cloudLow =  getPercentValue(DataCode(GRB_CLOUD_TOT,LV_CLOUD_LOW_LAYER,0));
+
+	cloudMid =  getPercentValue(DataCode(GRB_CLOUD_TOT,LV_CLOUD_MID_LAYER,0));
+	cloudHigh = getPercentValue(DataCode(GRB_CLOUD_TOT,LV_CLOUD_HIG_LAYER,0));
 			
 	hasCloudLayers = (cloudLow!=GRIB_NOTDEF) || (cloudMid!=GRIB_NOTDEF) || (cloudHigh!=GRIB_NOTDEF);
 
 	cloudLowTop = cloudLow<0.5 || reader==NULL ? GRIB_NOTDEF
-			: reader->getDateInterpolatedValue (DataCode(GRB_PRESSURE,LV_CLOUD_LOW_TOP,0), x,y,date);
+			: getPercentValue(DataCode(GRB_PRESSURE,LV_CLOUD_LOW_TOP,0));
 	cloudMidTop = cloudMid<0.5 || reader==NULL ? GRIB_NOTDEF
-			: reader->getDateInterpolatedValue (DataCode(GRB_PRESSURE,LV_CLOUD_MID_TOP,0), x,y,date);
+			: getPercentValue(DataCode(GRB_PRESSURE,LV_CLOUD_MID_TOP,0));
 	cloudHighTop = cloudHigh<0.5 || reader==NULL ? GRIB_NOTDEF
-			: reader->getDateInterpolatedValue (DataCode(GRB_PRESSURE,LV_CLOUD_HIG_TOP,0), x,y,date);
+			: getPercentValue(DataCode(GRB_PRESSURE,LV_CLOUD_HIG_TOP,0));
 	
 	cloudLowBottom = cloudLow<0.5 || reader==NULL ? GRIB_NOTDEF
-			: reader->getDateInterpolatedValue (DataCode(GRB_PRESSURE,LV_CLOUD_LOW_BOTTOM,0), x,y,date);
+			: getPercentValue(DataCode(GRB_PRESSURE,LV_CLOUD_LOW_BOTTOM,0));
 	cloudMidBottom = cloudMid<0.5 || reader==NULL ? GRIB_NOTDEF
-			: reader->getDateInterpolatedValue (DataCode(GRB_PRESSURE,LV_CLOUD_MID_BOTTOM,0), x,y,date);
+			: getPercentValue (DataCode(GRB_PRESSURE,LV_CLOUD_MID_BOTTOM,0));
 	cloudHighBottom = cloudHigh<0.5 || reader==NULL ? GRIB_NOTDEF
-			: reader->getDateInterpolatedValue (DataCode(GRB_PRESSURE,LV_CLOUD_HIG_BOTTOM,0), x,y,date);
+			: getPercentValue (DataCode(GRB_PRESSURE,LV_CLOUD_HIG_BOTTOM,0));
 	
 	//----------------------------------------
 	humidRel = reader==NULL ? GRIB_NOTDEF

--- a/src/DataPointInfo.h
+++ b/src/DataPointInfo.h
@@ -151,6 +151,12 @@ class DataPointInfo
         
 		
 	private:
+
+	float getPercentValue (const DataCode &c)
+	{
+	     return reader==NULL ? GRIB_NOTDEF: Util::inRangeOrNotDef(reader->getDateInterpolatedValue (c, x,y,date), 0., 100.);
+	}
+
         GriddedReader *reader;
         void initDataPointInfo();
         

--- a/src/MeteoTableWidget.cpp
+++ b/src/MeteoTableWidget.cpp
@@ -457,8 +457,6 @@ void MeteoTableWidget::createListVisibleGribData ()
         listVisibleData.append( new MTGribData (
                     DataCode(GRB_PRECIP_TOT,LV_GND_SURF,0).toInt32(), pos++) );
         listVisibleData.append( new MTGribData (
-                    DataCode(GRB_PRECIP_RATE,LV_GND_SURF,0).toInt32(), pos++) );
-        listVisibleData.append( new MTGribData (
     				DataCode(GRB_TEMP,LV_ABOV_GND,2).toInt32(), pos++) );
     	listVisibleData.append( new MTGribData (
     				DataCode(GRB_PRV_DIFF_TEMPDEW,LV_ABOV_GND,2).toInt32(), pos++) );

--- a/src/util/Util.cpp
+++ b/src/util/Util.cpp
@@ -660,7 +660,7 @@ QString Util::formatPercentValue(float v, bool withUnit)
 	if (v == GRIB_NOTDEF)
 		return withUnit ? "    %%": "   ";
     QString r;
-    if (v<0)
+    if (v <= 0.)
         v=0;
     else if (v>100)
         v=100;    

--- a/src/util/Util.h
+++ b/src/util/Util.h
@@ -193,6 +193,15 @@ class Util : public QObject
                         else return v;
                     }
     
+    //-------------------------------------------------
+    template <typename T>
+        static T inRangeOrNotDef(T v, T min, T max)
+                    {
+                        if (v == GRIB_NOTDEF)
+                            return v;
+                        return inRange(v, min, max);
+                    }
+
     //--------------------------------------------------------
     template <typename T>
         static void cleanListPointers (std::list <T*> & ls)


### PR DESCRIPTION
Hi,
- if there's no  config file two rows were created for precipitation
- display -0 as 0
- wgrib2 ncep_norm tcc output is not in 0..100 %

grib_dump  20180726_152618_GFS_P50_.grb2

> ...
> endStep = 6;
>  stepRange = 3-6;
>  shortNameECMF = unknown;
>  shortName = tcc;
> ...
> #-READ ONLY- maximum = 101;
> #-READ ONLY- minimum = -2;
> #-READ ONLY- average = 51.
