### PR TITLE
don't sync to disk on every setSetting call

### DIFF
--- a/src/DialogGraphicsParams.cpp
+++ b/src/DialogGraphicsParams.cpp
@@ -144,29 +144,30 @@ DialogGraphicsParams::DialogGraphicsParams (QWidget *parent) : DialogBoxBase (pa
 //-------------------------------------------------------------------------------
 void DialogGraphicsParams::slotBtOK()
 {
-	Util::setSetting("seaColor", inputSeaColor->getColor());
-	Util::setSetting("landColor", inputLandColor->getColor());
-	Util::setSetting("backgroundColor", inputBgColor->getColor());
+	QHash <QString, QVariant> h;
+	h.insert("seaColor", inputSeaColor->getColor());
+	h.insert("landColor", inputLandColor->getColor());
+	h.insert("backgroundColor", inputBgColor->getColor());
 	
-	Util::setSetting("seaBordersLineWidth", inputSeaBordersLine->getLineWidth());
-	Util::setSetting("seaBordersLineColor", inputSeaBordersLine->getLineColor());
-	Util::setSetting("boundariesLineWidth", inputBoundariesLine->getLineWidth());
-	Util::setSetting("boundariesLineColor", inputBoundariesLine->getLineColor());
-	Util::setSetting("riversLineWidth",   inputRiversLine->getLineWidth());
-	Util::setSetting("riversLineColor",   inputRiversLine->getLineColor());
-	Util::setSetting("isobarsLineWidth",  inputIsobarsLine->getLineWidth());
-	Util::setSetting("isobarsLineColor",  inputIsobarsLine->getLineColor());
-	Util::setSetting("isotherms0LineWidth",  inputIsotherms0Line->getLineWidth());
-	Util::setSetting("isotherms0LineColor",  inputIsotherms0Line->getLineColor());
-	Util::setSetting("isotherms_LineWidth",  inputIsotherms_Line->getLineWidth());
-	Util::setSetting("isotherms_LineColor",  inputIsotherms_Line->getLineColor());
-	Util::setSetting("linesThetaE_LineWidth",  inputThetaE_Line->getLineWidth());
-	Util::setSetting("linesThetaE_LineColor",  inputThetaE_Line->getLineColor());
-	Util::setSetting("geopotentials_LineWidth",  inputGeopotentials_Line->getLineWidth());
-	Util::setSetting("geopotentials_LineColor",  inputGeopotentials_Line->getLineColor());
+	h.insert("seaBordersLineWidth", inputSeaBordersLine->getLineWidth());
+	h.insert("seaBordersLineColor", inputSeaBordersLine->getLineColor());
+	h.insert("boundariesLineWidth", inputBoundariesLine->getLineWidth());
+	h.insert("boundariesLineColor", inputBoundariesLine->getLineColor());
+	h.insert("riversLineWidth",   inputRiversLine->getLineWidth());
+	h.insert("riversLineColor",   inputRiversLine->getLineColor());
+	h.insert("isobarsLineWidth",  inputIsobarsLine->getLineWidth());
+	h.insert("isobarsLineColor",  inputIsobarsLine->getLineColor());
+	h.insert("isotherms0LineWidth",  inputIsotherms0Line->getLineWidth());
+	h.insert("isotherms0LineColor",  inputIsotherms0Line->getLineColor());
+	h.insert("isotherms_LineWidth",  inputIsotherms_Line->getLineWidth());
+	h.insert("isotherms_LineColor",  inputIsotherms_Line->getLineColor());
+	h.insert("linesThetaE_LineWidth",  inputThetaE_Line->getLineWidth());
+	h.insert("linesThetaE_LineColor",  inputThetaE_Line->getLineColor());
+	h.insert("geopotentials_LineWidth",  inputGeopotentials_Line->getLineWidth());
+	h.insert("geopotentials_LineColor",  inputGeopotentials_Line->getLineColor());
 	
-	Util::setSetting("cloudsColorMode", inputCloudsColorMode->itemData(inputCloudsColorMode->currentIndex()).toString());
-    
+	h.insert("cloudsColorMode", inputCloudsColorMode->itemData(inputCloudsColorMode->currentIndex()).toString());
+	Util::setSettings(h);
     accept();
 }
 //-------------------------------------------------------------------------------

--- a/src/DialogLoadGRIB.cpp
+++ b/src/DialogLoadGRIB.cpp
@@ -312,46 +312,49 @@ void DialogLoadGRIB::slotGribReadProgress(int step, int done, int total)
 //-------------------------------------------------------------------------------
 void DialogLoadGRIB::saveParametersSettings ()
 {
-    Util::setSetting("downloadIndModel", cbModel->currentIndex());
-    Util::setSetting("downloadIndWaveModel", cbWvModel->currentIndex());
+    QHash <QString, QVariant> h;
 
-    Util::setSetting("downloadIndResolution", cbResolution->currentIndex());
-    Util::setSetting("downloadIndInterval",  cbInterval->currentIndex());
-	Util::setSetting("downloadIndNbDays",  cbDays->currentIndex());
-    Util::setSetting("downloadRunCycle",  cbRunCycle->itemData(cbRunCycle->currentIndex()));
+	h.insert("downloadIndModel", cbModel->currentIndex());
+    h.insert("downloadIndWaveModel", cbWvModel->currentIndex());
+
+    h.insert("downloadIndResolution", cbResolution->currentIndex());
+    h.insert("downloadIndInterval",  cbInterval->currentIndex());
+	h.insert("downloadIndNbDays",  cbDays->currentIndex());
+    h.insert("downloadRunCycle",  cbRunCycle->itemData(cbRunCycle->currentIndex()));
 	
-	Util::setSetting("downloadWind",  wind);
-	Util::setSetting("downloadPressure", pressure);
-	Util::setSetting("downloadRain",  rain);
-	Util::setSetting("downloadCloud", cloud);
-	Util::setSetting("downloadCloudLayers", cloudLayers);
-	Util::setSetting("downloadTemp",  temp);
-	Util::setSetting("downloadHumid", humid);
-	Util::setSetting("downloadIsotherm0", isotherm0);
+	h.insert("downloadWind",  wind);
+	h.insert("downloadPressure", pressure);
+	h.insert("downloadRain",  rain);
+	h.insert("downloadCloud", cloud);
+	h.insert("downloadCloudLayers", cloudLayers);
+	h.insert("downloadTemp",  temp);
+	h.insert("downloadHumid", humid);
+	h.insert("downloadIsotherm0", isotherm0);
 	
 //	Util::setSetting("downloadTempMin",  tempMin);
 //	Util::setSetting("downloadTempMax",  tempMax);
-	Util::setSetting("downloadSnowDepth", snowDepth);
-	Util::setSetting("downloadSnowCateg", snowCateg);
-	Util::setSetting("downloadFrzRainCateg", frzRainCateg);
-	Util::setSetting("downloadCAPEsfc", CAPEsfc);
-	Util::setSetting("downloadCINsfc", CINsfc);
-	Util::setSetting("downloadGUSTsfc", GUSTsfc);
+	h.insert("downloadSnowDepth", snowDepth);
+	h.insert("downloadSnowCateg", snowCateg);
+	h.insert("downloadFrzRainCateg", frzRainCateg);
+	h.insert("downloadCAPEsfc", CAPEsfc);
+	h.insert("downloadCINsfc", CINsfc);
+	h.insert("downloadGUSTsfc", GUSTsfc);
 //	Util::setSetting("downloadSUNSDsfc", SUNSDsfc);
 	
-	Util::setSetting("downloadAltitudeData200",  chkAltitude200->isChecked());
-	Util::setSetting("downloadAltitudeData300",  chkAltitude300->isChecked());
-	Util::setSetting("downloadAltitudeData400",  chkAltitude400->isChecked());
-	Util::setSetting("downloadAltitudeData500",  chkAltitude500->isChecked());
-	Util::setSetting("downloadAltitudeData600",  chkAltitude600->isChecked());
-	Util::setSetting("downloadAltitudeData700",  chkAltitude700->isChecked());
-	Util::setSetting("downloadAltitudeData850",  chkAltitude850->isChecked());
-	Util::setSetting("downloadAltitudeData925",  chkAltitude925->isChecked());
-	Util::setSetting("downloadSkewtData",  chkAltitude_SkewT->isChecked());
+	h.insert("downloadAltitudeData200",  chkAltitude200->isChecked());
+	h.insert("downloadAltitudeData300",  chkAltitude300->isChecked());
+	h.insert("downloadAltitudeData400",  chkAltitude400->isChecked());
+	h.insert("downloadAltitudeData500",  chkAltitude500->isChecked());
+	h.insert("downloadAltitudeData600",  chkAltitude600->isChecked());
+	h.insert("downloadAltitudeData700",  chkAltitude700->isChecked());
+	h.insert("downloadAltitudeData850",  chkAltitude850->isChecked());
+	h.insert("downloadAltitudeData925",  chkAltitude925->isChecked());
+	h.insert("downloadSkewtData",  chkAltitude_SkewT->isChecked());
 	
-    Util::setSetting("downoadWaveSig",  chkWaveSig->isChecked());
-    Util::setSetting("downloadWaveSwell",  chkWaveSwell->isChecked());
-    Util::setSetting("downloadWaveWind",  chkWaveWind->isChecked());
+    h.insert("downoadWaveSig",  chkWaveSig->isChecked());
+    h.insert("downloadWaveSwell",  chkWaveSwell->isChecked());
+    h.insert("downloadWaveWind",  chkWaveWind->isChecked());
+    Util::setSettings(h);
 }
 //-------------------------------------------------------------------------------
 void DialogLoadGRIB::updateParameters ()

--- a/src/DialogProxy.cpp
+++ b/src/DialogProxy.cpp
@@ -113,13 +113,13 @@ void DialogProxy::slotUseProxyChanged ()
 //-------------------------------------------------------------------------------
 void DialogProxy::slotBtOK()
 {
-    Util::setSetting("httpUseProxy", btUseProxy->isChecked());
-    Util::setSetting("httpProxyHostname", Util::encode(lineProxyHostname->text()));
-    Util::setSetting("httpProxyPort", lineProxyPort->text());
-    Util::setSetting("httpProxyUsername", Util::encode(lineProxyUserName->text()));
-    Util::setSetting("httpProxyUserPassword", Util::encode(lineProxyUserPassword->text()));
+    Util::setSetting("httpUseProxy", btUseProxy->isChecked(), false);
+    Util::setSetting("httpProxyHostname", Util::encode(lineProxyHostname->text()), false);
+    Util::setSetting("httpProxyPort", lineProxyPort->text(), false);
+    Util::setSetting("httpProxyUsername", Util::encode(lineProxyUserName->text()), false);
+    Util::setSetting("httpProxyUserPassword", Util::encode(lineProxyUserPassword->text()), false);
     Util::setSetting("httpProxyType", 
-					 cbProxyType->itemData (cbProxyType->currentIndex() ).toInt() );
+					 cbProxyType->itemData (cbProxyType->currentIndex() ).toInt(), false );
 	Util::setApplicationProxy ();
 
 //    Util::setSetting("strictHttpDownload", btStrictHttpDownload->isChecked());

--- a/src/DialogUnits.cpp
+++ b/src/DialogUnits.cpp
@@ -115,25 +115,25 @@ void DialogUnits::slotBtOK()
 	QComboBox *cb;
 	
 	cb = cbWindSpeedUnit;
-    Util::setSetting("unitsWindSpeed", cb->itemData(cb->currentIndex()).toString());
+    Util::setSetting("unitsWindSpeed", cb->itemData(cb->currentIndex()).toString(), false);
     cb = cbCurrentSpeedUnit;
-    Util::setSetting("unitsCurrentSpeed", cb->itemData(cb->currentIndex()).toString());
+    Util::setSetting("unitsCurrentSpeed", cb->itemData(cb->currentIndex()).toString(), false);
     cb = cbTempUnit;
-    Util::setSetting("unitsTemp",      cb->itemData(cb->currentIndex()).toString());
+    Util::setSetting("unitsTemp",      cb->itemData(cb->currentIndex()).toString(), false);
     cb = cbPositionUnit;
-    Util::setSetting("unitsPosition",  cb->itemData(cb->currentIndex()).toString());
+    Util::setSetting("unitsPosition",  cb->itemData(cb->currentIndex()).toString(), false);
     cb = cbDistanceUnit;
-    Util::setSetting("unitsDistance",  cb->itemData(cb->currentIndex()).toString());
+    Util::setSetting("unitsDistance",  cb->itemData(cb->currentIndex()).toString(), false);
 
     cb = cbAltitude;
-    Util::setSetting("geopotAltitudeUnit",  cb->itemData(cb->currentIndex()).toString());
+    Util::setSetting("geopotAltitudeUnit",  cb->itemData(cb->currentIndex()).toString(), false);
     cb = cbIsotherme0;
-    Util::setSetting("isotherm0Unit",  cb->itemData(cb->currentIndex()).toString());
+    Util::setSetting("isotherm0Unit",  cb->itemData(cb->currentIndex()).toString(), false);
 
  	cb = cbLongitude;
-    Util::setSetting("longitudeDirection", cb->itemData(cb->currentIndex()).toString());
+    Util::setSetting("longitudeDirection", cb->itemData(cb->currentIndex()).toString(), false);
     cb = cbLatitude;
-    Util::setSetting("latitudeDirection",  cb->itemData(cb->currentIndex()).toString());
+    Util::setSetting("latitudeDirection",  cb->itemData(cb->currentIndex()).toString(), false);
 
  	cb = cbTimeZone;
     Util::setSetting("timeZone",  cb->itemData(cb->currentIndex()).toString());
@@ -284,9 +284,9 @@ void DialogUnits::slotTimeZoneChanged(int index)
 		time_t locnow = QDateTime::currentDateTime().toTime_t();
     	
     	QString saveTimeZone = Util::getSetting("timeZone", "UTC").toString();
-		Util::setSetting("timeZone",  "UTC");
+		Util::setSetting("timeZone",  "UTC", false);
 		QString tutc = Util::formatDateTimeLong (locnow);
-		Util::setSetting("timeZone",  "LOC");
+		Util::setSetting("timeZone",  "LOC", false);
 		QString tloc = Util::formatDateTimeLong (locnow);
     	Util::setSetting("timeZone",  saveTimeZone);
 

--- a/src/ImageWriter.cpp
+++ b/src/ImageWriter.cpp
@@ -212,12 +212,12 @@ void ImageWriter::saveImage (time_t date)
 //-------------------------------------------------
 void ImageWriter::saveSettings (ImageWriterDialog &dial, QString filename)
 {
-	Util::setSetting("imageSaveWidth", dial.getW());
-	Util::setSetting("imageSaveHeight", dial.getH());
-	Util::setSetting("imageSaveQuality", dial.getQ());
-	Util::setSetting("imageSaveFilename", filename);
-	Util::setSetting("imageSaveResizeAfter", dial.getResizeAfter());
-	Util::setSetting("imageShowDateCursor", dial.getShowDateCursor());
+	Util::setSetting("imageSaveWidth", dial.getW(), false);
+	Util::setSetting("imageSaveHeight", dial.getH(), false);
+	Util::setSetting("imageSaveQuality", dial.getQ(), false);
+	Util::setSetting("imageSaveFilename", filename, false);
+	Util::setSetting("imageSaveResizeAfter", dial.getResizeAfter(), false);
+	Util::setSetting("imageShowDateCursor", dial.getShowDateCursor(), false);
 	Util::setSetting("imageShowColorScale", dial.getShowColorScale());
 }
 //-------------------------------------------------

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -662,9 +662,6 @@ void MainWindow::slotMap_Projection(QAction *act)
 	double x,y;    // current position
 	proj->screen2map(proj->getW()/2,proj->getH()/2, &x, &y);
 
-	Util::setSetting("projectionCX", proj->getCX());
-	Util::setSetting("projectionCY", proj->getCY());
-	Util::setSetting("projectionScale",  proj->getScale());
 	Util::setSetting("projectionId", idproj);
 
 	initProjection();
@@ -1255,17 +1252,17 @@ void MainWindow::slotGroupLinesThetaE_Step ()
 //-------------------------------------------------
 void MainWindow::slotGroupIsotherms (QAction *ac)
 {
-	Util::setSetting ("showIsotherms_2m", false);
-	Util::setSetting ("showIsotherms_925hpa", false);
-	Util::setSetting ("showIsotherms_850hpa", false);
-	Util::setSetting ("showIsotherms_700hpa", false);
-	Util::setSetting ("showIsotherms_600hpa", false);
-	Util::setSetting ("showIsotherms_500hpa", false);
-	Util::setSetting ("showIsotherms_400hpa", false);
+	Util::setSetting ("showIsotherms_2m", false, false);
+	Util::setSetting ("showIsotherms_925hpa", false, false);
+	Util::setSetting ("showIsotherms_850hpa", false, false);
+	Util::setSetting ("showIsotherms_700hpa", false, false);
+	Util::setSetting ("showIsotherms_600hpa", false, false);
+	Util::setSetting ("showIsotherms_500hpa", false, false);
+	Util::setSetting ("showIsotherms_400hpa", false, false);
 	Util::setSetting ("showIsotherms_300hpa", false);
 	if (ac && ac->isChecked()) {
 		Altitude alt;
-		Util::setSetting ("showIsotherms_200hpa", false);
+		Util::setSetting ("showIsotherms_200hpa", false, false);
 		if (ac == menuBar->acView_Isotherms_2m) {
 			alt = Altitude (LV_ABOV_GND,2);
 			Util::setSetting ("showIsotherms_2m", true);
@@ -1313,13 +1310,13 @@ void MainWindow::slotGroupIsotherms (QAction *ac)
 //-------------------------------------------------
 void MainWindow::slotGroupLinesThetaE (QAction *ac)
 {
-	Util::setSetting ("showLinesThetaE_925hpa", false);
-	Util::setSetting ("showLinesThetaE_850hpa", false);
-	Util::setSetting ("showLinesThetaE_700hpa", false);
-	Util::setSetting ("showLinesThetaE_600hpa", false);
-	Util::setSetting ("showLinesThetaE_500hpa", false);
-	Util::setSetting ("showLinesThetaE_400hpa", false);
-	Util::setSetting ("showLinesThetaE_300hpa", false);
+	Util::setSetting ("showLinesThetaE_925hpa", false, false);
+	Util::setSetting ("showLinesThetaE_850hpa", false, false);
+	Util::setSetting ("showLinesThetaE_700hpa", false, false);
+	Util::setSetting ("showLinesThetaE_600hpa", false, false);
+	Util::setSetting ("showLinesThetaE_500hpa", false, false);
+	Util::setSetting ("showLinesThetaE_400hpa", false, false);
+	Util::setSetting ("showLinesThetaE_300hpa", false, false);
 	Util::setSetting ("showLinesThetaE_200hpa", false);
 	if (ac) {
 		Altitude alt;

--- a/src/MeteotableOptionsDialog.cpp
+++ b/src/MeteotableOptionsDialog.cpp
@@ -86,12 +86,12 @@ void DialogMeteotableOptions::slotBtOK()
 	for (int i = 0; i < listAllOptionItems.size(); ++i) {
 		MeteotableOptionItem *item = listAllOptionItems.at(i);
 		uint grbcode = item->dtc.toInt32 ();
-		Util::setSetting (getSettingName_vis(grbcode), item->visible);
-		Util::setSetting (getSettingName_pos(grbcode), item->pos);
+		Util::setSetting (getSettingName_vis(grbcode), item->visible, false);
+		Util::setSetting (getSettingName_pos(grbcode), item->pos, false);
 	}
-	Util::setSetting("MTABLE_cloudsColorMode", inputCloudsColorMode->itemData(inputCloudsColorMode->currentIndex()).toString());
-	Util::setSetting("MTABLE_showWindArrows", cbShowWindArrows->isChecked());
-	Util::setSetting("MTABLE_showWindBeauforts", cbShowBeauforts->isChecked());
+	Util::setSetting("MTABLE_cloudsColorMode", inputCloudsColorMode->itemData(inputCloudsColorMode->currentIndex()).toString(), false);
+	Util::setSetting("MTABLE_showWindArrows", cbShowWindArrows->isChecked(), false);
+	Util::setSetting("MTABLE_showWindBeauforts", cbShowBeauforts->isChecked(), false);
 	Util::setSetting("MTABLE_showSunMoonAlmanac", cbSunMoonAlmanac->isChecked());
     
     accept();

--- a/src/Terrain.cpp
+++ b/src/Terrain.cpp
@@ -225,8 +225,8 @@ void Terrain::setProjection(Projection *proj)
     this->proj = proj;
     proj->setScreenSize( width(), height());
 	
-    Util::setSetting("projectionCX", proj->getCX());
-    Util::setSetting("projectionCY", proj->getCY());
+    Util::setSetting("projectionCX", proj->getCX(), false);
+    Util::setSetting("projectionCY", proj->getCY(), false);
     Util::setSetting("projectionScale",  proj->getScale());	
 	
 	QList<POI*> lpois = getListPOIs();

--- a/src/map/POI.cpp
+++ b/src/map/POI.cpp
@@ -147,19 +147,19 @@ void POI::readSettings (uint code, bool fnat)
 void POI::writeSettings ()
 {
 	//printf("write poi: %s\n", qPrintable(name));
-	Settings::setSettingPOI (code, "name", name);
-	Settings::setSettingPOI (code, "lon", lon);
-	Settings::setSettingPOI (code, "lat", lat);
-	Settings::setSettingPOI (code, "markColor", markColor);
-	Settings::setSettingPOI (code, "labelFont", labelFont);
-	Settings::setSettingPOI (code, "labelTextColor", labelTextColor);
+	Settings::setSettingPOI (code, "name", name, false);
+	Settings::setSettingPOI (code, "lon", lon, false);
+	Settings::setSettingPOI (code, "lat", lat, false);
+	Settings::setSettingPOI (code, "markColor", markColor, false);
+	Settings::setSettingPOI (code, "labelFont", labelFont, false);
+	Settings::setSettingPOI (code, "labelTextColor", labelTextColor, false);
 	// write stored bg-color for marked POIs, TH20110103
 	if (labelBgColorMarkedPOI.isValid()) {
-		Settings::setSettingPOI (code, "labelBgColor", labelBgColorMarkedPOI);
+		Settings::setSettingPOI (code, "labelBgColor", labelBgColorMarkedPOI, false);
 	}else {
-		Settings::setSettingPOI (code, "labelBgColor", labelBgColor);
+		Settings::setSettingPOI (code, "labelBgColor", labelBgColor, false);
 	}
-	Settings::setSettingPOI (code, "move", isMovable);
+	Settings::setSettingPOI (code, "move", isMovable, false);
 	Settings::setSettingPOI (code, "showLabel", showLabel);
 }
 

--- a/src/util/Settings.cpp
+++ b/src/util/Settings.cpp
@@ -118,16 +118,36 @@ void Settings::initializeSettingsDir ()
 }
 
 //---------------------------------------------------------------------
-void Settings::setApplicationNativeSetting
-            (const QString &group, const QString &key, const QVariant &value)
+void  Settings::setApplicationNativeSettings (const QString &group, const QHash <QString, QVariant> &h)
 {
-    if (GLOB_NatSettings != nullptr)
-    {
-        GLOB_NatSettings->beginGroup(group);
-        GLOB_NatSettings->setValue(key, value);
-        GLOB_NatSettings->endGroup();
-        GLOB_NatSettings->sync();
-    }
+	if (h.empty())
+		return;
+
+	if (GLOB_NatSettings == nullptr)
+		return;
+
+	GLOB_NatSettings->beginGroup(group);
+	QHash<QString, QVariant>::const_iterator i = h.constBegin();
+	while (i != h.constEnd()) {
+		GLOB_NatSettings->setValue(i.key(), i.value());
+		++i;
+	}
+	GLOB_NatSettings->endGroup();
+	GLOB_NatSettings->sync();
+}
+
+//---------------------------------------------------------------------
+void Settings::setApplicationNativeSetting
+			(const QString &group, const QString &key, const QVariant &value, bool sync)
+{
+	if (GLOB_NatSettings == nullptr)
+		return;
+
+	GLOB_NatSettings->beginGroup(group);
+	GLOB_NatSettings->setValue(key, value);
+	GLOB_NatSettings->endGroup();
+	if (sync)
+		GLOB_NatSettings->sync();
 }
 //---------------------------------------------------------------------
 QVariant Settings::getApplicationNativeSetting
@@ -144,19 +164,42 @@ QVariant Settings::getApplicationNativeSetting
     return val;
 }
 
-//---------------------------------------------------------------------
-void Settings::setUserSetting (const QString &key, const QVariant &value)
-{
-    // save 2 times the settings
-    Settings::setApplicationNativeSetting("main", key, value);
 
-    if (GLOB_IniSettings != nullptr)
-    {
-        GLOB_IniSettings->beginGroup("main");
-        GLOB_IniSettings->setValue(key, value);
-        GLOB_IniSettings->endGroup();
-        GLOB_IniSettings->sync();
-    }
+//---------------------------------------------------------------------
+void  Settings::setUserSettings (const QHash <QString, QVariant> &h)
+{
+	if (h.empty())
+		return;
+
+	Settings::setApplicationNativeSettings("main", h);
+
+	if (GLOB_IniSettings == nullptr)
+		return;
+
+	GLOB_IniSettings->beginGroup("main");
+	QHash<QString, QVariant>::const_iterator i = h.constBegin();
+	while (i != h.constEnd()) {
+		GLOB_IniSettings->setValue(i.key(), i.value());
+		++i;
+	}
+	GLOB_IniSettings->endGroup();
+	GLOB_IniSettings->sync();
+}
+
+//---------------------------------------------------------------------
+void Settings::setUserSetting (const QString &key, const QVariant &value, bool sync)
+{
+	// save 2 times the settings
+	Settings::setApplicationNativeSetting("main", key, value, sync);
+
+	if (GLOB_IniSettings == nullptr)
+		return;
+
+	GLOB_IniSettings->beginGroup("main");
+	GLOB_IniSettings->setValue(key, value);
+	GLOB_IniSettings->endGroup();
+	if (sync)
+		GLOB_IniSettings->sync();
 }
 //---------------------------------------------------------------------
 QVariant Settings::getUserSetting (const QString &key, const QVariant &defaultValue)
@@ -239,20 +282,21 @@ QVariant Settings::getSettingPOI
 }
 //---------------------------------------------------------------------
 void Settings::setSettingPOI
-				(uint code, const QString &key, const QVariant &value)
+				(uint code, const QString &key, const QVariant &value, bool sync)
 {
 	QString poikey = QString::number(code)+"/"+key;
 	
 	// save 2 times the settings : native and in ini file
-	Settings::setApplicationNativeSetting ("poi", poikey, value);
+	Settings::setApplicationNativeSetting ("poi", poikey, value, sync);
 	
-    if (GLOB_IniSettings_POI != nullptr)
-	{
-		GLOB_IniSettings_POI->beginGroup("poi");
-		GLOB_IniSettings_POI->setValue  (poikey, value);
-		GLOB_IniSettings_POI->endGroup();
+	if (GLOB_IniSettings_POI == nullptr)
+		return;
+
+	GLOB_IniSettings_POI->beginGroup("poi");
+	GLOB_IniSettings_POI->setValue  (poikey, value);
+	GLOB_IniSettings_POI->endGroup();
+	if (sync)
 		GLOB_IniSettings_POI->sync();
-	}
 }
 //---------------------------------------------------------------------
 QList<uint> Settings::getSettingAllCodesPOIs()

--- a/src/util/Settings.h
+++ b/src/util/Settings.h
@@ -55,11 +55,15 @@ public:
 	static QString  getSettingsFilename_POI ()
 						{ return GLOB_SettingsFilename_POI; }
 
-    static void     setUserSetting (const QString &key, const QVariant &value);
+    static void     setUserSettings (const QHash <QString, QVariant> &h);
+
+    static void     setUserSetting (const QString &key, const QVariant &value, bool sync = true);
     static QVariant getUserSetting (const QString &key, const QVariant &defaultValue);
     
+    static void     setApplicationNativeSettings (const QString &group, const QHash <QString, QVariant> &h);
     static void     setApplicationNativeSetting
-						(const QString &group, const QString &key, const QVariant &value);
+						(const QString &group, const QString &key, const QVariant &value, 
+						 bool sync = true);
     static QVariant getApplicationNativeSetting
 						(const QString &group, const QString &key, const QVariant &defaultValue);
 
@@ -70,7 +74,7 @@ public:
 	// POI's
 	//--------------------------------
     static void  setSettingPOI
-    					( uint code, const QString &key, const QVariant &value);    
+    					( uint code, const QString &key, const QVariant &value, bool sync = true);
     static QVariant getSettingPOI
 						( uint code, const QString &key, const QVariant &defaultValue,
 						  bool fromOldNativeSettings);

--- a/src/util/Util.cpp
+++ b/src/util/Util.cpp
@@ -35,12 +35,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 //======================================================================
-QHash <QString, QVariant> GLOB_hashSettings;
+static QHash <QString, QVariant> GLOB_hashSettings;
 
-void Util::setSetting (const QString &key, const QVariant &value)
+void Util::setSettings (const QHash <QString, QVariant> &h)
+{
+}
+
+void Util::setSetting (const QString &key, const QVariant &value, bool sync)
 {
 	GLOB_hashSettings.insert (key, value);
-	Settings::setUserSetting (key, value);
+	Settings::setUserSetting (key, value, sync);
 }
 //---------------------------------------------------------------------
 QVariant Util::getSetting (const QString &key, const QVariant &defaultValue)

--- a/src/util/Util.h
+++ b/src/util/Util.h
@@ -90,7 +90,8 @@ class Util : public QObject
     static QString pathTr  (QString lang)   {return pathData()+"data/tr/xyGrib_"+lang;}
 	static QString getServerName ();
 
-    static void     setSetting (const QString &key, const QVariant &value);
+    static void     setSettings (const QHash <QString, QVariant> &h);
+    static void     setSetting (const QString &key, const QVariant &value, bool sync = true);
     static QVariant getSetting (const QString &key, const QVariant &defaultValue);
 	static bool     isDirWritable (const QDir &dir);
 	static void     setApplicationProxy ();


### PR DESCRIPTION
Hi,
Currently every setSetting call is doing a disk sync, if storage is HD you can hear it.
This change add two methods for setting parameter without synchronizing:
-set all parameters from a dictionary. 
-a function sync parameter, default true, drawback last call must sync.

and sample using them.s

Regards
Didier