### PR TITLE
FIXME Arome, 52  is 'Total Precipitation Rate kg/m*m/s' but looks like kg/m*m aka a cumul

### DIFF
--- a/src/Grib2Record.cpp
+++ b/src/Grib2Record.cpp
@@ -556,7 +556,7 @@ int Grib2Record::analyseProductType ()
 			else if (paramnumber==49)
 				return GRB_PRECIP_TOT;
 			else if (paramnumber==52)
-				return GRB_PRECIP_RATE;
+				return GRB_PRECIP_TOT;// XXX return GRB_PRECIP_RATE;
 			else if (paramnumber==193)
 				return GRB_FRZRAIN_CATEG;
 			else if (paramnumber==195)


### PR DESCRIPTION
Hi,
Need some testing and maybe double checking with MeteoFrance but Grib param number doesn't seem to be the right one .

from:
https://donneespubliques.meteofrance.fr/?fond=faq&id_dossier=5#contenu_43

PRECIP
Total precipitation kg m**-2 (CUMUL)

Cumul (depuis le début de la simulation) de la somme des flux au sol des précipitations liquides et
solides (EAU + NEIGE  pour ARPEGE ; EAU + NEIGE  + GRAUPEL pour AROME)*

Regards
Didier