### PR TITLE
Use standard menu bar on MacOS

### DIFF
--- a/src/MenuBar.cpp
+++ b/src/MenuBar.cpp
@@ -59,8 +59,12 @@ MenuBar::MenuBar (QWidget *parent, bool mbe)
     : QMenuBar (parent)
 {
 #if defined (Q_OS_UNIX)
-	bool native = Util::getSetting("systemNativeMenuBar", false).toBool();
-	setNativeMenuBar (native);    // bug with some versions of ubuntu 
+    #if defined (Q_OS_MACOS)
+        bool native = Util::getSetting("systemNativeMenuBar", true).toBool();
+    #else
+        bool native = Util::getSetting("systemNativeMenuBar", false).toBool();
+    #endif
+        setNativeMenuBar (native);    // bug with some versions of ubuntu
 #endif
 
     this->maintenanceToolExists = mbe;


### PR DESCRIPTION
On macos only.
Before:
<img width="1124" alt="capture d ecran 2018-09-21 a 10 41 33" src="https://user-images.githubusercontent.com/22415254/45870352-fa766600-bd8a-11e8-8c0c-7489851b5f72.png">

After:
<img width="759" alt="capture d ecran 2018-09-21 a 10 41 07" src="https://user-images.githubusercontent.com/22415254/45870362-ff3b1a00-bd8a-11e8-9de2-82eff6c39dd0.png">
