### PR TITLE
Prefer libraries from other sources like Homebrew over frameworks on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_PREFIX}/cmake") 
 
+set(CMAKE_FIND_FRAMEWORK LAST)
+
 # Find the QtWidgets library
 find_package(Qt5Widgets CONFIG REQUIRED)
 include_directories(${Qt5Widgets_INCLUDE_DIRS})


### PR DESCRIPTION
Allows to a) finer control of what is used and b) works around what probably is a bug in which does not bundle proj.4 if it is linked from /Libraries/Frameworks

Closes #114