### PR TITLE
set a Level and some cleanups

### DIFF
--- a/src/Grib2Record.h
+++ b/src/Grib2Record.h
@@ -37,15 +37,6 @@ class Grib2RecordMarker {
 			this->levelType =levelType;
 			this->levelValue =levelValue;
 		}
-		Grib2RecordMarker(const Grib2RecordMarker &a)
-		{
-			this->id =a.id;
-			this->pdtnum =a.pdtnum;
-			this->paramcat =a.paramcat;
-			this->paramnumber =a.paramnumber;
-			this->levelType =a.levelType;
-			this->levelValue =a.levelValue;
-		}
 		bool operator== (const Grib2RecordMarker &a)   // same product, ignore altitude
 		{
 			return 	this->id==a.id && this->pdtnum ==a.pdtnum 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1859,6 +1859,19 @@ void MainWindow::setMenubarColorMapData (const DataCode &dtc, bool trigAction)
 }
 
 //=======================================================================
+static DataCode
+preferedIsobaricLevel(int dataType, GriddedReader *reader)
+{
+	DataCode dtc;
+    dtc.set (GRB_TYPE_NOT_DEFINED, LV_TYPE_NOT_DEFINED, 0);
+	for (auto level : {925, 850, 700, 600, 500, 400, 300, 200 } ) {
+        dtc.set (dataType, LV_ISOBARIC, level);
+        if (reader->hasData(dtc))
+            break;
+    }
+	return dtc;
+}
+
 void MainWindow::slot_GroupColorMap (QAction *act)
 {
     if (! terre->getGriddedPlotter() || ! terre->getGriddedPlotter()->isReaderOk())    {
@@ -1891,30 +1904,8 @@ void MainWindow::slot_GroupColorMap (QAction *act)
 		dtctmp.set (GRB_PRV_WIND_XY2D,LV_ABOV_GND,10); 
 		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
 			dtc = dtctmp;
-		dtctmp.set (GRB_PRV_WIND_XY2D,LV_ISOBARIC,925); 
-		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
-			dtc = dtctmp;
-		dtctmp.set (GRB_PRV_WIND_XY2D,LV_ISOBARIC,850); 
-		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
-			dtc = dtctmp;
-		dtctmp.set (GRB_PRV_WIND_XY2D,LV_ISOBARIC,700); 
-		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
-			dtc = dtctmp;
-		dtctmp.set (GRB_PRV_WIND_XY2D,LV_ISOBARIC,600); 
-		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
-			dtc = dtctmp;
-		dtctmp.set (GRB_PRV_WIND_XY2D,LV_ISOBARIC,500); 
-		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
-			dtc = dtctmp;
-		dtctmp.set (GRB_PRV_WIND_XY2D,LV_ISOBARIC,400); 
-		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
-			dtc = dtctmp;
-		dtctmp.set (GRB_PRV_WIND_XY2D,LV_ISOBARIC,300); 
-		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
-			dtc = dtctmp;
-		dtctmp.set (GRB_PRV_WIND_XY2D,LV_ISOBARIC,200); 
-		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
-			dtc = dtctmp;
+        if (dtc.dataType==GRB_TYPE_NOT_DEFINED)
+            dtc = preferedIsobaricLevel(GRB_PRV_WIND_XY2D, reader);
 	}
     // TODO this needs to be fixed there are a number of levels of current
     else if (act == mb->acView_CurrentColors)
@@ -1929,15 +1920,22 @@ void MainWindow::slot_GroupColorMap (QAction *act)
             if (reader->hasData(dtctmp))
                 dtc.set (GRB_PRECIP_RATE,LV_GND_SURF,0);
         }
-
-
     }
     else if (act == mb->acView_CloudColors)
     	dtc.set (GRB_CLOUD_TOT,LV_ATMOS_ALL,0);
     else if (act == mb->acView_HumidColors)
     	dtc.set (GRB_HUMID_REL,LV_ABOV_GND,2);
-    else if (act == mb->acView_TempColors)
-    	dtc.set (GRB_TEMP,LV_ABOV_GND,2);
+    else if (act == mb->acView_TempColors) {
+		dtc.set (GRB_TYPE_NOT_DEFINED,LV_TYPE_NOT_DEFINED,0);
+		dtctmp.set (GRB_TEMP,LV_ABOV_GND,2);
+		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
+			dtc = dtctmp;
+        dtctmp.set (GRB_TEMP,LV_ABOV_GND,0);
+		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
+			dtc = dtctmp;
+        if (dtc.dataType==GRB_TYPE_NOT_DEFINED)
+            dtc = preferedIsobaricLevel(GRB_TEMP, reader);
+    }
     else if (act == mb->acView_DeltaDewpointColors)
     	dtc.set (GRB_PRV_DIFF_TEMPDEW,LV_ABOV_GND,2);
     else if (act == mb->acView_SnowCateg)
@@ -1956,31 +1954,8 @@ void MainWindow::slot_GroupColorMap (QAction *act)
     //-----------------------------------
     else if (act == mb->acView_ThetaEColors)
 	{	// search "prefered" altitude for theta-e
-		dtc.set (GRB_TYPE_NOT_DEFINED,LV_TYPE_NOT_DEFINED,0); 
-		dtctmp.set (GRB_PRV_THETA_E,LV_ISOBARIC,850); 
-		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
-			dtc = dtctmp;
-		dtctmp.set (GRB_PRV_THETA_E,LV_ISOBARIC,925); 
-		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
-			dtc = dtctmp;
-		dtctmp.set (GRB_PRV_THETA_E,LV_ISOBARIC,700); 
-		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
-			dtc = dtctmp;
-		dtctmp.set (GRB_PRV_THETA_E,LV_ISOBARIC,600); 
-		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
-			dtc = dtctmp;
-		dtctmp.set (GRB_PRV_THETA_E,LV_ISOBARIC,500); 
-		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
-			dtc = dtctmp;
-		dtctmp.set (GRB_PRV_THETA_E,LV_ISOBARIC,400); 
-		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
-			dtc = dtctmp;
-		dtctmp.set (GRB_PRV_THETA_E,LV_ISOBARIC,300); 
-		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
-			dtc = dtctmp;
-		dtctmp.set (GRB_PRV_THETA_E,LV_ISOBARIC,200); 
-		if (dtc.dataType==GRB_TYPE_NOT_DEFINED && reader->hasData(dtctmp))
-			dtc = dtctmp;
+	    dtc = preferedIsobaricLevel(GRB_PRV_THETA_E, reader);
+
 	}
 	//-----------------------------------
     else if (act == mb->acView_SigWaveHeight)

--- a/src/MapDrawer.cpp
+++ b/src/MapDrawer.cpp
@@ -492,7 +492,7 @@ void MapDrawer::draw_MeteoData_Gridded
 
 	if (showGeopotential) {
         pnt.setPen (geopotentialsPen);
-	addUsedDataCenterModel(geopotentialData, plotter);
+        addUsedDataCenterModel(geopotentialData, plotter);
 		plotter->complete_listIsolines (&listGeopotential,
 						   geopotentialData,
 						   geopotentialMin, geopotentialMax, geopotentialStep, proj);
@@ -570,13 +570,15 @@ void MapDrawer::draw_MeteoData_Gridded
 						Font::getFont(FONT_GRIB_PressHL),
 						QColor(0,0,0), pnt, proj);
 	}
-	if (showTemperatureLabels) {
+	if (showTemperatureLabels ) {
 		DataCode dtc (GRB_TEMP,temperatureLabelsAlt);
-		addUsedDataCenterModel (dtc, plotter);
-		plotter->draw_DATA_Labels (
+		if (plotter->hasData (dtc)) {
+			addUsedDataCenterModel (dtc, plotter);
+			plotter->draw_DATA_Labels (
 					dtc, Font::getFont(FONT_GRIB_Temp),
 					QColor(0,0,0),
 					Util::formatTemperature_short, pnt, proj);
+		}
 	}
 
 	//===================================================
@@ -651,9 +653,13 @@ void MapDrawer::draw_Cartouche_Gridded
 			datalist.append (tr("Isotherms")+" "+AltitudeStr::toStringShort(isothermsAltitude)+" "+tr("(°C)"));
 		if (showLinesThetaE)
 			datalist.append (tr("Theta-e")+" "+AltitudeStr::toStringShort(linesThetaEAltitude)+" "+tr("(°C)"));
-		if (showTemperatureLabels)
-			datalist.append (tr("Temperature")
+		if (showTemperatureLabels) {
+			DataCode dtc (GRB_TEMP,temperatureLabelsAlt);
+			if (plotter->hasData (dtc)) {
+				datalist.append (tr("Temperature label")
 					+" ("+AltitudeStr::toStringShort(temperatureLabelsAlt)+")");
+			}
+		}
 		if (showGeopotential)
 			datalist.append (tr("Geopotential")
 					+" "+AltitudeStr::toStringShort(geopotentialData.getAltitude())

--- a/src/Therm.h
+++ b/src/Therm.h
@@ -21,8 +21,6 @@ class TPoint
 	public:
 		TPoint (double tempC=GRIB_NOTDEF, double hpa=GRIB_NOTDEF)
 						{this->tempC=tempC; this->hpa=hpa;}
-		TPoint& operator= (const TPoint &other)
-						{tempC=other.tempC; hpa=other.hpa; return *this;}
 		bool   ok ()  {return hpa!=GRIB_NOTDEF && tempC!=GRIB_NOTDEF;}
 		double hpa;      // altitude
 		double tempC;    // °C	

--- a/src/map/GshhsRangsReader.cpp
+++ b/src/map/GshhsRangsReader.cpp
@@ -377,7 +377,8 @@ void GshhsRangsReader::drawGshhsRangsMapPlain( QPainter &pnt, Projection *proj,
             cxx -= 360;
         
         for (cy=cymin; cy<cymax; cy++) {
-            if (cxx>=0 && cxx<=359 && cy>=-90 && cy<=89)
+            assert(cxx>=0 && cxx<=359);
+            if (cy>=-90 && cy<=89)
             {
                 if (allCells[cxx][cy+90] == nullptr) {
 					cel = new GshhsRangsCell(fcat, fcel, frim, cxx, cy);
@@ -424,7 +425,8 @@ void GshhsRangsReader::drawGshhsRangsMapSeaBorders( QPainter &pnt, Projection *p
             cxx -= 360;
         
         for (cy=cymin; cy<cymax; cy++) {
-            if (cxx>=0 && cxx<=359 && cy>=-90 && cy<=89)
+            assert(cxx>=0 && cxx<=359);
+            if (cy>=-90 && cy<=89)
             {
                 if (allCells[cxx][cy+90] == nullptr) {
 					cel = new GshhsRangsCell(fcat, fcel, frim, cxx, cy);


### PR DESCRIPTION
Hi,

Should fix #119 
- With altitude 850mb chosen and Temperature coloring selected the coloring does not work. This does work for wind at 850mb.

In my understanding:
- With altitude 850mb chosen wind arrows do not display unless wind coloring is selected
is the normal behavior, hard to understand though.
If wind overlay display arrows  for selected level if wind arrows set.
if not wind overlay display wind 10m if wind arrow.

Same for
- Temp at 10m option is not grayed out although temp at 10m is not part of the file
if by 10m you mean 2m.
