### PR TITLE
Add build targets to update translations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 install:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]];
       then 
-          sudo apt-get install build-essential git cmake qt5-default libpng-dev  libnova-dev libproj-dev zlib1g-dev libbz2-dev qttools5-dev-tools;
+          sudo apt-get install build-essential git cmake qt5-default libpng-dev  libnova-dev libproj-dev zlib1g-dev libbz2-dev qttools5-dev-tools qttools5-dev;
       fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then grep -q trusty /etc/lsb-release || sudo apt-get install libopenjpeg-dev || true; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]];

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 install:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]];
       then 
-          sudo apt-get install build-essential git cmake qt5-default libpng-dev  libnova-dev libproj-dev zlib1g-dev libbz2-dev; 
+          sudo apt-get install build-essential git cmake qt5-default libpng-dev  libnova-dev libproj-dev zlib1g-dev libbz2-dev qttools5-dev-tools;
       fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then grep -q trusty /etc/lsb-release || sudo apt-get install libopenjpeg-dev || true; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]];

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,7 @@ set(PREFIX_PKGDATA ${PROJECT_NAME})
 endif()
 
 add_subdirectory(src)
+add_subdirectory(data/tr)
 
 # Installation
 # macOS bundle parameters

--- a/data/tr/CMakeLists.txt
+++ b/data/tr/CMakeLists.txt
@@ -1,0 +1,12 @@
+set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM 1)
+
+FIND_PACKAGE(Qt5LinguistTools)
+
+file(GLOB TRANSLATION_FILES ${CMAKE_CURRENT_LIST_DIR}/*.ts)
+set_source_files_properties(${TRANSLATION_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_CURRENT_SOURCE_DIR})
+
+qt5_create_translation(TRANSLATION_MESSAGES ${CMAKE_CURRENT_SOURCE_DIR}/../../src ${TRANSLATION_FILES})
+qt5_add_translation(TRANSLATION_QM ${TRANSLATION_FILES})
+add_custom_target(translations_update DEPENDS ${TRANSLATION_MESSAGES})
+add_custom_target(translations DEPENDS ${TRANSLATION_QM})
+


### PR DESCRIPTION
Adds 2 new build targets to update translations
- `make translations_update` updates the TS files form source code
- `make translations` generates the QM build products (Do we really want to have them in the source tree?)
Both take time and modify the source tree so they are not included in the standard build process and have to be run explicitly.

Closes #121 