### PR TITLE
Fix debianizing for V1.1.2 release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-xygrib (1.1.1-1) unstable; urgency=medium
+xygrib (1.1.2-1) unstable; urgency=medium
 
-  * Initial release 
+  * Release 1.1.2 
 
- -- Oleg Roitburd <oroitburd@gmail.com>  Tue, 10 Jul 2018 09:44:01 +0200
+ -- Oleg Roitburd <oroitburd@gmail.com>  Tue, 16 Oct 2018 09:44:01 +0200

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,1 @@
-paths.patch
+#paths.patch

--- a/debian/xygrib-maps.install
+++ b/debian/xygrib-maps.install
@@ -1,2 +1,2 @@
-data/maps/gshhs/* /usr/share/maps/gshhs
-data/gis/* /usr/share/maps/gis
+data/maps/gshhs/* /usr/share/openGribs/XyGrib/data/maps/gshhs
+data/gis/* /usr/share/openGribs/XyGrib/data/gis

--- a/debian/xygrib.dirs
+++ b/debian/xygrib.dirs
@@ -1,5 +1,1 @@
-/usr/share/icons/xygrib
-/usr/share/qt5/translations
-/usr/share/applications
-/usr/share/pixmaps
-/usr/share/xygrib/data/colors
+/usr/share/xygrib

--- a/debian/xygrib.dirs
+++ b/debian/xygrib.dirs
@@ -1,1 +1,1 @@
-/usr/share/xygrib
+/usr/share/openGribs/XyGrib/data

--- a/debian/xygrib.install
+++ b/debian/xygrib.install
@@ -1,7 +1,7 @@
-data/colors /usr/share/xygrib/
-data/img /usr/share/xygrib/
-data/tr /usr/share/xygrib/
-data/fonts /usr/share/xygrib/
+data/colors /usr/share/openGribs/XyGrib/data/
+data/img /usr/share/openGribs/XyGrib/data/
+data/tr /usr/share/openGribs/XyGrib/data/
+data/fonts /usr/share/openGribs/XyGrib/data/
 debian/tmp/usr/XyGrib/XyGrib /usr/bin
 debian/xygrib.desktop /usr/share/applications
 debian/xygrib.png /usr/share/pixmaps

--- a/debian/xygrib.install
+++ b/debian/xygrib.install
@@ -1,6 +1,7 @@
-data/tr/*.qm /usr/share/qt5/translations
-data/img/* /usr/share/icons/xygrib
-data/colors/* /usr/share/xygrib/data/colors
+data/colors /usr/share/xygrib/
+data/img /usr/share/xygrib/
+data/tr /usr/share/xygrib/
+data/fonts /usr/share/xygrib/
 debian/tmp/usr/XyGrib/XyGrib /usr/bin
 debian/xygrib.desktop /usr/share/applications
 debian/xygrib.png /usr/share/pixmaps


### PR DESCRIPTION
Hi,
This PR fixes the bugs in packaging 1.1.2 for Debian based distributions
Tested with Debian Stretch 9 ( amd64, armhf) and Ubuntu 18.04/Mint19

regards
free-x