### PR TITLE
Initialize Grib record timeRange to missing(255)

### DIFF
--- a/src/GribRecord.h
+++ b/src/GribRecord.h
@@ -168,7 +168,7 @@ class GribRecord : public RegularGridRecord
         bool   hasBMS;
         zuint  refyear, refmonth, refday, refhour, refminute;
         zuchar periodP1, periodP2;
-        zuchar timeRange;
+        zuchar timeRange{255};
         zuint  periodsec;    // period in seconds
         time_t refDate;      // Reference date
         time_t curDate;      // Current date


### PR DESCRIPTION
Hi
This commit should be backport to a new 1.2.1 branch, there's too much change in master for using it.

Regards
Didier
 