### PR TITLE
adding a new gshhs option to cater for Linux standard practices

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -411,7 +411,9 @@ mb->acMap_SelectMETARs->setVisible (false);	// TODO
     //-------------------------------------------------------
     connect(mb->acHelp_Help, SIGNAL(triggered()), this, SLOT(slotHelp_Help()));
     connect(mb->acHelp_APropos, SIGNAL(triggered()), this, SLOT(slotHelp_APropos()));
+#ifndef NO_UPDATE // deactivates SW update if cmake -DCMAKE_CXX_FLAGS="-DNO_UPDATE=1"
     connect(mb->acCheckForUpdates, SIGNAL(triggered()), this, SLOT(slotCheckForUpdates()));
+#endif
 
     if (maintenanceToolLocation != "")
         connect(mb->acRunMaintenanceTool, SIGNAL(triggered()), this, SLOT(slotRunMaintenanceTool()));

--- a/src/MenuBar.cpp
+++ b/src/MenuBar.cpp
@@ -425,7 +425,11 @@ MenuBar::MenuBar (QWidget *parent, bool mbe)
         				tr("Help"), tr("Ctrl+H"),
         				"",Util::pathImg("help.png"));
         acHelp_APropos = addAction (menuHelp, tr("About XyGrib"),"","","");
+#ifndef NO_UPDATE   // deactivates SW update if cmake -DCMAKE_CXX_FLAGS="-DNO_UPDATE=1"
         acCheckForUpdates = addAction (menuHelp, tr("Check for updates"),"","","");
+#else
+        DBGS(SW update option was deactivated at compilation time);
+#endif
 
         if (maintenanceToolExists)
             acRunMaintenanceTool = addAction (menuHelp, tr("Run XyGrib Maintenance Tool"),"",

--- a/src/MenuBar.h
+++ b/src/MenuBar.h
@@ -305,7 +305,9 @@ public:
 
     QAction *acHelp_Help;
     QAction *acHelp_APropos;
+#ifndef NO_UPDATE // deactivates SW update if cmake -DCMAKE_CXX_FLAGS="-DNO_UPDATE=1"
     QAction *acCheckForUpdates;
+#endif
 //#ifdef Q_OS_WIN
     QAction *acRunMaintenanceTool;
 //#endif

--- a/src/util/Settings.cpp
+++ b/src/util/Settings.cpp
@@ -534,12 +534,12 @@ bool Settings::findAppDataDir ()
         // in windows binaries it does exist for sure. This will put app data in c:/user/AppData/Roaming...
         dir = QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
 #else
-        dir = QDir(QStandardPaths::writableLocation(QStandardPaths::DataLocation));
+        dir = QDir(QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation));
 #endif
         QDir maps = QDir(dir.absolutePath() + "/data/maps");
         QDir gis = QDir(dir.absolutePath() + "/data/gis");
 
-        DBGQS("Searching in: " + dir.absolutePath());
+        DBGQS("option1: Searching in: " + dir.absolutePath());
         if (maps.exists() && gis.exists()) { // we have the location
             path = dir.absolutePath();
             Settings::setUserSetting("appDataDir", path); // store the location in settings
@@ -550,10 +550,33 @@ bool Settings::findAppDataDir ()
     if (path == "")
     {	// second option is to locate app data files in shared area
 
-        slist = QStandardPaths::standardLocations(QStandardPaths::DataLocation);
+        slist = QStandardPaths::standardLocations(QStandardPaths::AppLocalDataLocation);
         foreach (QString str, slist)
         {
-            DBGQS("Searching in: " + str);
+            DBGQS("option2: Searching in: " + str);
+
+            dir = QDir(str);
+            QDir maps = QDir(dir.absolutePath() + "/data/maps");
+            QDir gis = QDir(dir.absolutePath() + "/data/gis");
+
+            if (maps.exists() && gis.exists()) { // we have the location
+                path = dir.absolutePath();
+                Settings::setUserSetting("appDataDir", path); // store the location in settings
+                DBGQS("Shared location search was good and is: " + path);
+                break;
+            }
+        }
+    }
+
+      if (path == "")
+    {	// third option is to locate app data files in shared area use in Linux packaging
+
+        slist = QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);
+        foreach (QString str, slist)
+        {
+            // typical install directory by packager will be in /usr/share/XyGrib
+            str = str+"/"+QCoreApplication::applicationName();
+            DBGQS("option3: Searching in: " + str);
 
             dir = QDir(str);
             QDir maps = QDir(dir.absolutePath() + "/data/maps");
@@ -569,9 +592,9 @@ bool Settings::findAppDataDir ()
     }
 
     if (path == "")
-    {	// third option is to look under application current directory
+    {	// forth option is to look under application current directory
         dir = QDir::current();
-        DBGQS("Searching in current dir: " + dir.absolutePath());
+        DBGQS("option4: Searching in current dir: " + dir.absolutePath());
         QDir maps = QDir(dir.absolutePath() + "/data/maps");
         QDir gis = QDir(dir.absolutePath() + "/data/gis");
 

--- a/src/util/Util.h
+++ b/src/util/Util.h
@@ -34,7 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "DataDefines.h"
 
-//#define DEBUG
+// #define DEBUG
 
 #ifdef DEBUG
 #define DBG(...) { 	\


### PR DESCRIPTION
This patch reduce the risk for XyGrib to not find the GSHHS chart on first use.
Signed-off-by: Dominig ar Foll Intel Open Source <dominig.arfoll@fridu.net>