### PR TITLE
properly center grib crossing IDL or 0 lon

### DIFF
--- a/src/GribReader.cpp
+++ b/src/GribReader.cpp
@@ -864,9 +864,9 @@ double 	GribReader::get2GribsInterpolatedValueByDate (
 bool GribReader::getZoneExtension (double *x0,double *y0, double *x1,double *y1)
 {
     if (ok) {
-        *x0 = (getXmin () > 180) ? getXmin() - 360 : getXmin();
+        *x0 = getXmin();
 		*y0 = getYmin ();
-        *x1 = (getXmax () > 180) ? getXmax() - 360 : getXmax();
+        *x1 = getXmax();
 		*y1 = getYmax ();
         return true;
     }

--- a/src/Terrain.cpp
+++ b/src/Terrain.cpp
@@ -831,7 +831,12 @@ void  Terrain::showSpecialZone (bool b)
 //---------------------------------------------------------
 void Terrain::zoomOnZone (double x0, double y0, double x1, double y1)
 {
+	DBG("zoom on x0 %f x1 %f\n", x0, x1);
 	double mh, mv;
+	if (x0 > x1) {
+		x0 -= 360.;
+		DBG("NEW zoom on x0 %f x1 %f\n", x0, x1);
+	}
 	mh = fabs(x0-x1)*0.05;
 	mv = fabs(y0-y1)*0.05;
 	proj->setVisibleArea (x0-mh,y0-mv, x1+mh,y1+mv);


### PR DESCRIPTION
Hi,
Xygrib doesn't properly center and display grib area for grib crossing IDL.
![bad_2019-01-09_22-38-50](https://user-images.githubusercontent.com/12138026/50930132-69251f80-145f-11e9-9e69-159a6fa194f9.png)

Patched version
![good_2019-01-09_22-37-16](https://user-images.githubusercontent.com/12138026/50930133-69bdb600-145f-11e9-8e26-7017f3cf0135.png)

Regards
Didier
