### PR TITLE
WIP If no MSL pressure use SFC pressure if available

### DIFF
--- a/src/BoardPanel.cpp
+++ b/src/BoardPanel.cpp
@@ -85,7 +85,9 @@ void BoardPanel::showDataPointInfo (
 	if (cellPressure->isVisible()) {
 		if (pf.hasPressureMSL())
 			lbPres.setText (Util::formatPressure (pf.pressureMSL));
-		else
+		else if (pf.hasPressureSFC())
+			lbPres.setText (Util::formatPressure (pf.pressureSFC));
+        else
 			lbPres.setText("");
 	}
 	if (cellGust->isVisible()) {

--- a/src/DataPointInfo.cpp
+++ b/src/DataPointInfo.cpp
@@ -49,6 +49,7 @@ DataPointInfo::DataPointInfo (GriddedReader *reader,
         rain = getValue(DataCode(GRB_PRECIP_RATE,LV_GND_SURF,0));
 
     pressureMSL = getValue(DataCode(GRB_PRESSURE_MSL,LV_MSL,0));
+    pressureSFC = getValue(DataCode(GRB_PRESSURE, LV_GND_SURF,0));
 	//----------------------------------------
 	// Waves
 	//----------------------------------------
@@ -243,6 +244,10 @@ float DataPointInfo::getDataValue (const DataCode &dtc) const
 			return snowDepth;
 		case GRB_PRESSURE_MSL : 
 			return pressureMSL;
+		case GRB_PRESSURE :
+			if (dtc.levelType==LV_GND_SURF && dtc.levelValue==0)
+				return pressureSFC;
+			return GRIB_NOTDEF;
 		case GRB_PRECIP_TOT   : 
         case GRB_PRECIP_RATE  :
             return rain;
@@ -268,8 +273,7 @@ float DataPointInfo::getDataValue (const DataCode &dtc) const
 				assert (idx >= 0);
 				return hTemp [idx];
 			}
-			else
-				return temp;
+			return temp;
 		case GRB_GEOPOT_HGT   :
 			if (dtc.levelType == LV_ISOTHERM0)
 				return isotherm0HGT;
@@ -285,24 +289,21 @@ float DataPointInfo::getDataValue (const DataCode &dtc) const
 				assert (idx >= 0);
 				return hHumidRel [idx];
 			}
-			else
-				return humidRel;
+			return humidRel;
 		case GRB_HUMID_SPEC   : 
 			if (dtc.getAltitude().levelType == LV_ISOBARIC) {
 				int idx = dtc.getAltitude().index();
 				assert (idx >= 0);
 				return hHumidSpec [idx];
 			}
-			else
-				return humidSpec;
+			return humidSpec;
 		case GRB_PRV_THETA_E      : 
 			if (dtc.getAltitude().levelType == LV_ISOBARIC) {
 				int idx = dtc.getAltitude().index();
 				assert (idx >= 0);
 				return hThetae [idx];
 			}
-			else
-				return GRIB_NOTDEF;
+			return GRIB_NOTDEF;
 		//-----------------------------------
 		// Waves
 		//-----------------------------------

--- a/src/DataPointInfo.h
+++ b/src/DataPointInfo.h
@@ -31,6 +31,7 @@ class DataPointInfo
 		float getDataValue (const DataCode &dtc) const;
 		
         bool hasPressureMSL() const {return GribDataIsDef(pressureMSL);}
+        bool hasPressureSFC() const {return GribDataIsDef(pressureSFC);}
         bool hasTemp()     const {return GribDataIsDef(temp);}
         bool hasTempMin()  const {return GribDataIsDef(tempMin);}
         bool hasTempMax()  const {return GribDataIsDef(tempMax);}
@@ -89,6 +90,7 @@ class DataPointInfo
 		float   windSpeed_gnd;
 		float   windDir_gnd;
         float   pressureMSL;
+        float   pressureSFC;
         float   rain;
         float   tempMin;
         float   tempMax;

--- a/src/GribRecord.cpp
+++ b/src/GribRecord.cpp
@@ -86,7 +86,7 @@ void  GribRecord::translateDataType ()
 			&& getLevelValue()==0) {
 				dataType  = GRB_PRESSURE_MSL;
 		}
-		if ( (getDataType()==GRB_CLOUD_TOT)
+		else if ( (getDataType()==GRB_CLOUD_TOT)
 			&& getLevelType()==LV_GND_SURF
 			&& getLevelValue()==0) {
 				levelType  = LV_ATMOS_ALL;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -769,6 +769,8 @@ void MainWindow::openMeteoDataFile (const QString& fileName)
 			menuBar->acView_DeltaDewpointColors->setEnabled(ok);
 
 			ok = plotter->hasData (GRB_PRESSURE_MSL,LV_MSL,0);
+            if (!ok)
+                ok = plotter->hasData (GRB_PRESSURE, LV_GND_SURF,0);
 			menuBar->acView_Isobars->setEnabled(ok);
 			menuBar->acView_IsobarsLabels->setEnabled(ok);
 			menuBar->acView_PressureMinMax->setEnabled(ok);

--- a/src/MapDrawer.cpp
+++ b/src/MapDrawer.cpp
@@ -461,8 +461,11 @@ void MapDrawer::draw_MeteoData_Gridded
 	std::vector <IsoLine *> listIsotherms;
 	std::vector <IsoLine *> listLinesThetaE;
 
-	if (! plotter->hasData (GRB_PRESSURE_MSL,LV_MSL,0))
-		showIsobars = false;
+	if (! plotter->hasData (GRB_PRESSURE_MSL,LV_MSL,0)) {
+		if (! plotter->hasData (GRB_PRESSURE, LV_GND_SURF,0))
+			showIsobars = false;
+	}
+
 	if (! plotter->hasData (GRB_GEOPOT_HGT,LV_ISOTHERM0,0))
 		showIsotherms0 = false;
 	if (! plotter->hasData (geopotentialData))
@@ -475,6 +478,9 @@ void MapDrawer::draw_MeteoData_Gridded
 	if (showIsobars) {
 		pnt.setPen (isobarsPen);
 		DataCode dtc (GRB_PRESSURE_MSL,LV_MSL,0);
+		if (! plotter->hasData (dtc)) {
+			dtc = {GRB_PRESSURE, LV_GND_SURF,0};
+		}
 		addUsedDataCenterModel (dtc, plotter);
 		plotter->complete_listIsolines (&listIsobars, dtc,
 						   84000, 112000, isobarsStep*100, proj);
@@ -643,8 +649,13 @@ void MapDrawer::draw_Cartouche_Gridded
 		if (colorMapData.dataType != GRB_TYPE_NOT_DEFINED)
 			datalist.append (DataCodeStr::toString_levelShort (colorMapData));
 		
-		if (showIsobars)
-			datalist.append (tr("Isobars MSL (hPa)"));
+		if (showIsobars) {
+			DataCode dtc (GRB_PRESSURE_MSL,LV_MSL,0);
+			if (! plotter->hasData (dtc))
+				datalist.append (tr("Isobars sfc (hPa)"));
+			else
+				datalist.append (tr("Isobars MSL (hPa)"));
+		}
 		if (showIsotherms0)
 			datalist.append (tr("Isotherms 0°C") 
 				+" (" 

--- a/src/MeteoTable.cpp
+++ b/src/MeteoTable.cpp
@@ -538,6 +538,7 @@ int MeteoTableDialog::SYLK_addData_gen (SylkFile &slk, int lig,int col, DataCode
 				case GRB_WIND_GUST	  : 
 					txt = Util::formatSpeed_Wind (val, false); 
 					break;
+				case GRB_PRESSURE :
 				case GRB_PRESSURE_MSL : 
 					txt = Util::formatPressure (val, false); 
 					break;

--- a/src/MeteoTableWidget.cpp
+++ b/src/MeteoTableWidget.cpp
@@ -192,6 +192,9 @@ void MeteoTableWidget::createTable()
 	lig ++;
 	addCell_title_dataline ("", true, lig,col);
 	col ++;
+	bool msl = true;
+	bool pressure = false;
+
 	for (long date : sdates)
 	{
 		addCell_title(Util::formatTime(date), false, layout, lig,col, 1,1,
@@ -200,6 +203,16 @@ void MeteoTableWidget::createTable()
 
 		// Grib data for this point and this date
 		pinfo = new DataPointInfo (reader, lon,lat, date);
+		if (pinfo->hasPressureMSL() )
+		{
+			pressure = true;
+			msl = true;
+		}
+		if (pressure == false && pinfo->hasPressureSFC())
+		{
+			pressure = true;
+			msl = false;
+		}
 		lspinfos.push_back (pinfo);
 		lsdates.push_back (date);
 	}
@@ -222,6 +235,12 @@ void MeteoTableWidget::createTable()
 			addLine_Current (alt, lig++);
 		}
 		else if (dataType==GRB_PRESSURE_MSL && levelType==LV_MSL && levelValue==0){
+			Altitude alt (levelType, levelValue);
+			if (msl == false)
+				alt = {LV_GND_SURF, 0 };
+			addLine_Pressure (alt, lig++);
+		}
+		else if (dataType==GRB_PRESSURE && levelType==LV_GND_SURF && levelValue==0){
 			Altitude alt (levelType, levelValue);
 			addLine_Pressure (alt, lig++);
 		}
@@ -525,6 +544,10 @@ void MeteoTableWidget::addLine_Pressure(const Altitude &alt, int lig)
 		if (pinfo->hasPressureMSL()) {
 			txt = Util::formatPressure (pinfo->pressureMSL);
 			bgColor = QColor(plotter->getPressureColor(pinfo->pressureMSL, true));
+		}
+		else if (pinfo->hasPressureSFC()) {
+			txt = Util::formatPressure (pinfo->pressureSFC);
+			bgColor = QColor(plotter->getPressureColor(pinfo->pressureSFC, true));
 		}
 		else
 			bgColor = Qt::white;

--- a/src/util/Util.cpp
+++ b/src/util/Util.cpp
@@ -383,6 +383,7 @@ QString Util::getDataUnit (const DataCode &dtc)
 		case GRB_PRECIP_TOT   : 
 			return tr("mm/h");
 		case GRB_PRESSURE_MSL : 
+		case GRB_PRESSURE :
 			return tr("hPa");
 		case GRB_WAV_SIG_HT : 
 		case GRB_WAV_WND_HT : 


### PR DESCRIPTION
Hi,

Arome Meteo France 0.01 has only surface pressure not mean sea level. 
Display it but not as a fake MSL. 
They have an altitude grib available so computing MSL from surface should be doable though (with a 12 hours lag for temperature?).
You can get some pre-cut sample at: 
http://176.31.74.196/OPENGRIBS/
(I mask pressure over land) 

There's still a couple of misleading MSL (menu and values panel), If we decide commit this one, I'll fix them first.

Regards
Didier
