### PR TITLE
Unicode paths

### DIFF
--- a/src/Grib2Reader.cpp
+++ b/src/Grib2Reader.cpp
@@ -28,7 +28,7 @@ Grib2Reader::~Grib2Reader ()
 {
 }
 //-------------------------------------------------------------------------------
-void Grib2Reader::openFile (const std::string &fname, int nbrecs)
+void Grib2Reader::openFile (const QString &fname, int nbrecs)
 {
 	allUnknownRecords.clear();
 	continueDownload = true;
@@ -36,7 +36,7 @@ void Grib2Reader::openFile (const std::string &fname, int nbrecs)
 	setAllDates.clear ();
 	setAllDataCode.clear ();
 	
-    if (!fname.empty()) {
+    if (!fname.isEmpty()) {
         openFilePriv (fname, nbrecs);
 		createListDates ();
 		ok = getNumberOfDates() > 0;
@@ -51,7 +51,7 @@ void Grib2Reader::openFile (const std::string &fname, int nbrecs)
     }
 }
 //-------------------------------------------------------------------------------
-void Grib2Reader::openFilePriv (const std::string& fname, int nbrecs)
+void Grib2Reader::openFilePriv (const QString& fname, int nbrecs)
 {
 //     debug("Open file: %s", fname.c_str());
     fileName = fname;
@@ -60,9 +60,9 @@ void Grib2Reader::openFilePriv (const std::string& fname, int nbrecs)
     //--------------------------------------------------------
     // Ouverture du fichier
     //--------------------------------------------------------
-    file = zu_open (fname.c_str(), "rb", ZU_COMPRESS_AUTO);
+    file = zu_open (qPrintable(fname), "rb", ZU_COMPRESS_AUTO);
     if (file == nullptr) {
-        erreur("Can't open file: %s", fname.c_str());
+        erreur("Can't open file: %s", qPrintable(fname));
         return;
     }
 	emit newMessage (LongTaskMessage::LTASK_OPEN_FILE);

--- a/src/Grib2Reader.h
+++ b/src/Grib2Reader.h
@@ -37,10 +37,10 @@ class Grib2Reader : public GribReader
         Grib2Reader ();
         ~Grib2Reader ();
 		
-        virtual void  openFile (const std::string &fname, int nbrecs);
+        virtual void  openFile (const QString &fname, int nbrecs);
 		
 	private:
-        void openFilePriv (const std::string& fname, int nbrecs);
+        void openFilePriv (const QString& fname, int nbrecs);
 		void readGrib2FileContent (int nbrecs);
 
 		void analyseRecords ();

--- a/src/GribPlot.cpp
+++ b/src/GribPlot.cpp
@@ -65,7 +65,7 @@ void GribPlot::loadGrib (LongTaskProgress * taskProgress, int nbrecs)
 	    QObject::connect(taskProgress,   &LongTaskProgress::canceled,
 	    		gribReader, &LongTaskMessage::cancel);
     }
-    gribReader->openFile (qPrintable(fileName), nbrecs);
+    gribReader->openFile (fileName, nbrecs);
     if (gribReader->isOk())
     {
         listDates = gribReader->getListDates();

--- a/src/GribReader.cpp
+++ b/src/GribReader.cpp
@@ -36,14 +36,14 @@ GribReader::GribReader()
 	ymax = -1e300;
 }
 //-------------------------------------------------------------------------------
-void GribReader::openFile (const std::string &fname, int nbrecs)
+void GribReader::openFile (const QString &fname, int nbrecs)
 {
 	continueDownload = true;
 	setAllDataCenterModel.clear();
 	setAllDates.clear ();
 	setAllDataCode.clear ();
 	
-    if (!fname.empty()) {
+    if (!fname.isEmpty()) {
         openFilePriv (fname, nbrecs);
     }
     else {
@@ -933,7 +933,7 @@ void GribReader::createListDates()
 //-------------------------------------------------------------------------------
 // Lecture complète d'un fichier GRIB
 //-------------------------------------------------------------------------------
-void GribReader::openFilePriv (const std::string& fname, int nbrecs)
+void GribReader::openFilePriv (const QString& fname, int nbrecs)
 {
 //     debug("Open file: %s", fname.c_str());
     fileName = fname;
@@ -942,9 +942,9 @@ void GribReader::openFilePriv (const std::string& fname, int nbrecs)
     //--------------------------------------------------------
     // Ouverture du fichier
     //--------------------------------------------------------
-    file = zu_open (fname.c_str(), "rb", ZU_COMPRESS_AUTO);
+    file = zu_open (qPrintable(fname), "rb", ZU_COMPRESS_AUTO);
     if (file == nullptr) {
-        erreur("Can't open file: %s", fname.c_str());
+        erreur("Can't open file: %s", qPrintable(fname));
         return;
     }
     

--- a/src/GribReader.h
+++ b/src/GribReader.h
@@ -37,7 +37,7 @@ class GribReader : public RegularGridReader, public LongTaskMessage
         GribReader ();
         ~GribReader ();
 		
-        virtual void  openFile (const std::string &fname, int nbrecs);
+        virtual void  openFile (const QString &fname, int nbrecs);
 		
 		virtual FileDataType getReaderFileDataType () 
 					{return DATATYPE_GRIB;};
@@ -110,7 +110,7 @@ class GribReader : public RegularGridReader, public LongTaskMessage
 		
         std::map <uint64_t, std::vector<GribRecord *>* >  mapGribRecords;
 
-        void   openFilePriv (const std::string& fname, int nbrecs);
+        void   openFilePriv (const QString& fname, int nbrecs);
 		void   readGribFileContent (int nbrecs);
 		void   readAllGribRecords  (int nbrecs);
         

--- a/src/GriddedReader.h
+++ b/src/GriddedReader.h
@@ -42,7 +42,7 @@ class GriddedReader : public DataReaderAbstract
 
 		//virtual void openFile (const std::string fname) = 0;
 		long  getFileSize ()          {return fileSize;}
-		std::string getFileName ()    {return fileName;}
+		QString getFileName ()    {return fileName;}
 
 		/// Give the englobing rectangle of all data.
 		virtual bool getZoneExtension 
@@ -88,7 +88,7 @@ class GriddedReader : public DataReaderAbstract
 		
 	protected:
         bool   ok;
-        std::string fileName;
+        QString fileName;
         long    fileSize;
 		double xmin,xmax, ymin,ymax;
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -488,7 +488,7 @@ MainWindow::MainWindow (int w, int h, QWidget *parent)
 	
     //--------------------------------------------------
     int mapQuality = 0;
-    gshhsReader =  std::make_shared<GshhsReader>(Util::pathGshhs().toStdString(), mapQuality);
+    gshhsReader =  std::make_shared<GshhsReader>(Util::pathGshhs(), mapQuality);
 	
     //--------------------------------------------------
     terre = new Terrain (this, proj, gshhsReader);
@@ -1560,7 +1560,9 @@ void MainWindow::slotFile_Info_GRIB ()
 		return;
     }
     QString msg;
-	msg += tr("File : %1\n") .arg( reader->getFileName().c_str());
+    QString f = QString::fromStdString(reader->getFileName());
+
+	msg += tr("File : %1\n") .arg( qPrintable(f));
 	msg += tr("Size : %1 bytes\n") .arg(reader->getFileSize());
 	msg += "\n";
 	msg += tr("Weather center %1") .arg(record->getIdCenter());

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1560,9 +1560,8 @@ void MainWindow::slotFile_Info_GRIB ()
 		return;
     }
     QString msg;
-    QString f = QString::fromStdString(reader->getFileName());
 
-	msg += tr("File : %1\n") .arg( qPrintable(f));
+	msg += tr("File : %1\n") .arg(reader->getFileName());
 	msg += tr("Size : %1 bytes\n") .arg(reader->getFileSize());
 	msg += "\n";
 	msg += tr("Weather center %1") .arg(record->getIdCenter());

--- a/src/map/GshhsRangsReader.cpp
+++ b/src/map/GshhsRangsReader.cpp
@@ -282,7 +282,7 @@ void GshhsRangsCell::drawSeaBorderLines(QPainter &pnt, double dx, Projection *pr
 //========================================================================
 //========================================================================
 //========================================================================
-GshhsRangsReader::GshhsRangsReader(const std::string &rangspath)
+GshhsRangsReader::GshhsRangsReader(const QString &rangspath)
 {
     path = rangspath+"/";
 	currentQuality = -1;
@@ -325,9 +325,9 @@ void GshhsRangsReader::setQuality(int quality)  // 5 levels: 0=low ... 4=full
 		if (frim)
 			fclose(frim);
 		
-		fcat = fopen( (path+"rangs_"+txtn+".cat").c_str(), "rb");
-		fcel = fopen( (path+"rangs_"+txtn+".cel").c_str(), "rb");
-		frim = fopen( (path+"gshhs_"+txtn+".rim").c_str(), "rb");
+		fcat = fopen( qPrintable(path+"rangs_"+txtn+".cat"), "rb");
+		fcel = fopen( qPrintable(path+"rangs_"+txtn+".cel"), "rb");
+		frim = fopen( qPrintable(path+"gshhs_"+txtn+".rim"), "rb");
 		
 		for (auto & allCell : allCells) {
 			for (auto & j : allCell) {

--- a/src/map/GshhsRangsReader.h
+++ b/src/map/GshhsRangsReader.h
@@ -102,7 +102,7 @@ class GshhsRangsCell
 class GshhsRangsReader
 {
     public:
-        GshhsRangsReader(const std::string &path_);
+        GshhsRangsReader(const QString &path_);
         ~GshhsRangsReader();
 
         void drawGshhsRangsMapPlain( QPainter &pnt, Projection *proj,
@@ -114,7 +114,7 @@ class GshhsRangsReader
 
     private:
     	int currentQuality;
-        std::string path;
+        QString path;
         FILE *fcat{}, *fcel{}, *frim{};
         GshhsRangsCell * allCells[360][180]{};
 };

--- a/src/map/GshhsReader.cpp
+++ b/src/map/GshhsReader.cpp
@@ -108,7 +108,7 @@ GshhsPolygon::~GshhsPolygon() {
 //==========================================================
 //==========================================================
 //==========================================================
-GshhsReader::GshhsReader (const std::string& fpath, int quality)
+GshhsReader::GshhsReader (const QString& fpath, int quality)
 {
     this->fpath = fpath;
     gshhsRangsReader = new GshhsRangsReader(fpath);
@@ -199,9 +199,9 @@ void GshhsReader::clearLists ()
 }
 //-----------------------------------------------------------------------
 // extension du nom de fichier gshhs selon la qualité
-std::string GshhsReader::getNameExtension(int quality)
+QString GshhsReader::getNameExtension(int quality)
 {
-    std::string ext;
+    QString ext;
     switch (quality) {
         case 0: ext = "c"; break;
         case 1: ext = "l"; break;
@@ -213,52 +213,52 @@ std::string GshhsReader::getNameExtension(int quality)
     return ext;
 }
 //-----------------------------------------------------------------------
-std::string GshhsReader::getFileName_gshhs (int quality)
+QString GshhsReader::getFileName_gshhs (int quality)
 {
     // Lit le .rim de RANGS à la place du fichier initial
     char txtn[16];
     if (quality < 0)   quality = 0;
     if (quality > 4)   quality = 4;
     snprintf(txtn, 10, "%d", 4-quality);   // précision inversée :(
-    std::string fname;
+    QString fname;
     fname = fpath+"/"+"gshhs_" + txtn + ".rim";
 	//printf("%s\n", fname.c_str());
     return fname;
 }
-std::string GshhsReader::getFileName_boundaries (int quality) {
-    std::string fname, ext;
-    ext = getNameExtension(quality);
+QString GshhsReader::getFileName_boundaries (int quality) {
+    QString fname;
+    auto ext = getNameExtension(quality);
     fname = fpath+"/"+"wdb_borders_" + ext + ".b";
     return fname;
 }
-std::string GshhsReader::getFileName_rivers (int quality) {
-    std::string fname, ext;
-    ext = getNameExtension(quality);
+QString GshhsReader::getFileName_rivers (int quality) {
+    QString fname;
+    auto  ext = getNameExtension(quality);
     fname = fpath+"/"+"wdb_rivers_" + ext + ".b";
     return fname;
 }
 //-----------------------------------------------------------------------
 bool GshhsReader::gshhsFilesExists(int quality)
 {
-    if (zu_can_read_file (getFileName_gshhs(quality).c_str() ) == 0)
+    if (zu_can_read_file (qPrintable(getFileName_gshhs(quality))) == 0)
         return false;
-    if (zu_can_read_file (getFileName_boundaries(quality).c_str() ) == 0)
+    if (zu_can_read_file (qPrintable(getFileName_boundaries(quality))) == 0)
         return false;
-    if (zu_can_read_file (getFileName_rivers(quality).c_str() ) == 0)
+    if (zu_can_read_file (qPrintable(getFileName_rivers(quality))) == 0)
         return false;
     return true;
 }
 //-----------------------------------------------------------------------
 void GshhsReader::readGshhsFiles()
 {
-    std::string fname;
+    QString fname;
     ZUFILE *file;
     bool   ok;
 
 	// Bordures des continents (4 niveaux) (gshhs_[clihf].b)
 	if (lsPoly_level1[quality]->empty()) { // on ne lit qu'une fois le fichier
 		fname = getFileName_gshhs(quality);
-		file = zu_open(fname.c_str(), "rb");
+		file = zu_open(qPrintable(fname), "rb");
         if (file != nullptr) {
 			
 			ok = true;
@@ -292,7 +292,7 @@ void GshhsReader::setUserPreferredQuality(int quality_) // 5 levels: 0=low ... 4
 //-----------------------------------------------------------------------
 void GshhsReader::setQuality(int quality_) // 5 levels: 0=low ... 4=full
 {
-    std::string fname;
+    QString fname;
     ZUFILE *file;
     bool   ok;
 
@@ -309,7 +309,7 @@ void GshhsReader::setQuality(int quality_) // 5 levels: 0=low ... 4=full
     // Frontières politiques
     if (lsPoly_boundaries[quality]->empty()) { // on ne lit qu'une fois le fichier
         fname = getFileName_boundaries(quality);
-        file = zu_open(fname.c_str(), "rb");
+        file = zu_open(qPrintable(fname), "rb");
         if (file != nullptr) {
             ok = true;
             while (ok) {
@@ -328,7 +328,7 @@ void GshhsReader::setQuality(int quality_) // 5 levels: 0=low ... 4=full
     // Rivières
     if (lsPoly_rivers[quality]->empty()) { // on ne lit qu'une fois le fichier
         fname = getFileName_rivers(quality);
-        file = zu_open(fname.c_str(), "rb");
+        file = zu_open(qPrintable(fname), "rb");
         if (file != nullptr) {
             ok = true;
             while (ok) {

--- a/src/map/GshhsReader.h
+++ b/src/map/GshhsReader.h
@@ -102,7 +102,7 @@ class GshhsPolygon_WDB : public GshhsPolygon
 class GshhsReader
 {
     public:
-        GshhsReader (const std::string& fpath, int quality);
+        GshhsReader (const QString& fpath, int quality);
         GshhsReader (const GshhsReader &model);
         ~GshhsReader();
         
@@ -125,15 +125,15 @@ class GshhsReader
         void setQuality (int quality);
 		void selectBestQuality (Projection *proj);
 
-        std::string fpath;     // directory containing gshhs files
+        QString fpath;     // directory containing gshhs files
         
         GshhsRangsReader * gshhsRangsReader;
         bool               isUsingRangsReader;
         
-        std::string getNameExtension (int quality);
-        std::string getFileName_gshhs (int quality);
-        std::string getFileName_boundaries (int quality);
-        std::string getFileName_rivers (int quality);
+        QString getNameExtension (int quality);
+        QString getFileName_gshhs (int quality);
+        QString getFileName_boundaries (int quality);
+        QString getFileName_rivers (int quality);
         void		readGshhsFiles ();
         
         //-----------------------------------------------------


### PR DESCRIPTION
Hi,
cf https://github.com/opengribs/XyGrib/issues/108

Dealing with paths is a pain in the a... for minimizing  roundtrip conversion errors this PR tries to keep pathname as an opaque blob as possible. 

Note:
- using qPrintable is not a good idea, but it was already used. I think it doesn't work in all cases, ie if pathname has unicode characters not available in the current locale, worse there's no guarantee pathname encoding is valid in any locale. 

- Xygrib should not used fopen, maybe not so easy with zu_open bzip2 decompressor. 

- bad, but saved setting grib filename is locale sensitive,ie 
echo $LANG
fr_FR.UTF-8
wine ./Xygrib.exe # save a file with an unicode character
LANG=C wine ./Xygrib.exe # file not found error
I'm not sure it's fixable on Windows with only Qt functions. 

Regards
Didier


