### PR TITLE
Ecmwf era5

### DIFF
--- a/src/GribRecord.cpp
+++ b/src/GribRecord.cpp
@@ -315,13 +315,13 @@ void  GribRecord::translateDataType ()
         dataCenterModel = ECMWF_ERA5;
         switch (getDataType()) {
         case 229: // SWH Significant height of combined wind waves and swell (m)
-            dataType = 100;
+            dataType = GRB_WAV_SIG_HT;
             break;
         case 230: // MWD Mean wave direction (Degree true)
-            dataType = 101; // XXX right parameter?
+            dataType = GRB_WAV_PRIM_DIR;
             break;
-        case 232: // MWP Mean wave period  (s)
-            dataType = 102; // XXX right parameter?
+        case 232: // MWP Mean wave period (s)
+            dataType = GRB_WAV_PRIM_PER;
             break;
         }
     }

--- a/src/GribRecord.cpp
+++ b/src/GribRecord.cpp
@@ -1329,6 +1329,8 @@ double GribRecord::getInterpolatedValue (double px, double py, bool interpolate)
 		}
     } 
     else {
+        if (px < xmin)
+            px += 360.;
 		pi = (px-xmin)/Di;
 		i0 = (int) floor(pi);  // point 00
 		i1 = i0+1;
@@ -1463,8 +1465,7 @@ double GribRecord::getValueOnRegularGrid (DataCode dtc, int i, int j ) const
 {
 	if ( getDataCode() != dtc )
 		return GRIB_NOTDEF;
-	else
-		return getValue (i,j);
+    return getValue (i,j);
 }
 //--------------------------------------------------------------------------
 double  GribRecord::getInterpolatedValue (
@@ -1474,8 +1475,7 @@ double  GribRecord::getInterpolatedValue (
 {
 	if ( getDataCode() != dtc )
 		return GRIB_NOTDEF;
-	else
-		return getInterpolatedValueUsingRegularGrid (dtc,px,py,interpolate);
+    return getInterpolatedValueUsingRegularGrid (dtc,px,py,interpolate);
 }
 
 

--- a/src/GribRecord.cpp
+++ b/src/GribRecord.cpp
@@ -287,6 +287,7 @@ void  GribRecord::translateDataType ()
             {
                 dataType = GRB_CLOUD_TOT;
                 levelType = LV_ATMOS_ALL;
+                multiplyAllData( 100.0 );
             }
             else if (getDataType() == 228)
             {

--- a/src/GribRecord.h
+++ b/src/GribRecord.h
@@ -96,7 +96,7 @@ class GribRecord : public RegularGridRecord
 						{ return ok ? Ni*Nj/((xmax-xmin)*(-ymin)) : 0; }
 
         // coordonnées d'un point de la grille
-        void getXY(int i, int j, double *lon, double *lat) const {
+        void getXY(int i, int j, double *lon, double *lat) const override {
                 *lon = getX(i);
                 *lat = getY(j);
             }
@@ -138,8 +138,8 @@ class GribRecord : public RegularGridRecord
         virtual void  print (const char *title);
 
     private:
-        double  getX(int i) const   { return ok ? xmin+i*Di : GRIB_NOTDEF;}
-        double  getY(int j) const   { return ok ? ymin+j*Dj : GRIB_NOTDEF;}
+        double  getX(int i) const override { return ok ? xmin+i*Di : GRIB_NOTDEF;}
+        double  getY(int j) const override { return ok ? ymin+j*Dj : GRIB_NOTDEF;}
 
     protected:
         int    id;         // unique identifiant

--- a/src/GribRecord.h
+++ b/src/GribRecord.h
@@ -103,7 +103,7 @@ class GribRecord : public RegularGridRecord
 
         // Valeur pour un point de la grille
         double getValue (int i, int j) const 
-							{ return ok ? data[j*Ni+i] : GRIB_NOTDEF;}
+							{ return ok && i>=0 && i<Ni && j>=0 && j<Nj ? data[j*Ni+i] : GRIB_NOTDEF;}
 		
         // Valeur pour un point quelconque
         double  getInterpolatedValue (
@@ -138,8 +138,8 @@ class GribRecord : public RegularGridRecord
         virtual void  print (const char *title);
 
     private:
-        double  getX(int i) const override { return ok ? xmin+i*Di : GRIB_NOTDEF;}
-        double  getY(int j) const override { return ok ? ymin+j*Dj : GRIB_NOTDEF;}
+        double  getX(int i) const override { return ok && i>= 0 && i < Ni? xmin+i*Di : GRIB_NOTDEF;}
+        double  getY(int j) const override { return ok && j >= 0 && j < Nj? ymin+j*Dj : GRIB_NOTDEF;}
 
     protected:
         int    id;         // unique identifiant

--- a/src/GriddedRecord.cpp
+++ b/src/GriddedRecord.cpp
@@ -63,8 +63,11 @@ double  GriddedRecord::getInterpolatedValueUsingRegularGrid (
 			while (px< 0)
 				px += 360;
 		}
-    } 
-    
+    }
+    else {
+        if (px < xmin)
+            px += 360.;
+    }
     pi = (px-xmin)/getDeltaX();
     i0 = (int) floor(pi);  // point 00
 	i1 = i0+1;

--- a/src/map/Projection.cpp
+++ b/src/map/Projection.cpp
@@ -55,14 +55,27 @@ void Projection::updateBoundaries () {
     
     xmin = x0;
     xmax = x1;
-    
+    double ofs{360.};
+    double dec{360.};
+
+    if (xmax > ofs) {
+    	xmax -= dec;
+    	xmin -= dec;
+    	CX -= dec;
+    }
+    else if (xmin < -ofs) {
+    	xmax += dec;
+    	xmin += dec;
+    	CX += dec;
+    }
+
 	if (y0 < y1) {
 		double a = y1; y1 = y0; y0 = a;
 	}
     ymin = y1;
     ymax = y0;
 		    
-//printf("Projection::updateBoundaries X(%f %f) Y(%f %f)\n", xmin,xmax, ymin,ymax);
+// printf("Projection::updateBoundaries X(%f %f) Y(%f %f)\n", xmin,xmax, ymin,ymax);
 
 	if (W*H != 0)
 		coefremp = 10000.0*fabs( ((xmax-xmin)*(ymax-ymin)) / (W*H) );


### PR DESCRIPTION
Hi,
- I can't reproduce the whole world Windows error with wine but clang found stuff so it should be ok.
- map mean wave to primary wave.
- in my understanding we have to multiply cloud value by 100.

Still doesn't always properly redraw the whole world, it's not a regression.
Mostly ok for zygrib projection, bad with Mercator.
Internal gshhs representation range is 0/360 or -90/270 for segments crossing Greenwich.
 drawing is done twice: 
GSHHS_scaledPoints(pol, pts, 0, proj);
and then with a -360. degree offset

GSHHS_scaledPoints(pol, pts, -360, proj);
 
but it's a hack, only good enough with zygrib projection and 4/3 screens.