### PR TITLE
wave arrows.

### DIFF
--- a/src/DataColors.cpp
+++ b/src/DataColors.cpp
@@ -194,132 +194,56 @@ QRgb  DataColors::pasteToWindColorScale
 	return getWindColor (Util::BeaufortToMs_F(eqbeauf), smooth);
 }
 //--------------------------------------------------------------------------
-void DataColors::setColorDataTypeFunction (const DataCode &dtc)
+auto DataColors::getFunctionColor(const DataCode &dtc) -> QRgb (DataColors::*)(double v, bool smooth)
 {
 	switch (dtc.dataType) {
-		case GRB_WIND_GUST :
-			function_getColor = &DataColors::getGustColor;
-			break;
+		case GRB_WIND_GUST : return &DataColors::getGustColor;
 		case GRB_WIND_SPEED :
 		case GRB_PRV_WIND_XY2D :
-			function_getColor = &DataColors::getWindColor;
-			break;
-		case GRB_PRV_WIND_JET :
-			function_getColor = &DataColors::getWindJetColor;
-			break;
-		case GRB_PRV_THETA_E :
-			function_getColor = &DataColors::getThetaEColor;
-			break;
+			return &DataColors::getWindColor;
+		case GRB_PRV_WIND_JET : return  &DataColors::getWindJetColor;
+		case GRB_PRV_THETA_E :  return &DataColors::getThetaEColor;
 		case GRB_CUR_SPEED :
 		case GRB_PRV_CUR_XY2D :
-			function_getColor = &DataColors::getCurrentColor;
-			break;
-		case GRB_PRV_DIFF_TEMPDEW :
-			function_getColor = &DataColors::getDeltaTemperaturesColor;
-			break;
-		case GRB_CLOUD_TOT : 
-			function_getColor = &DataColors::getCloudColor;
-			break;
+			return &DataColors::getCurrentColor;
+		case GRB_PRV_DIFF_TEMPDEW : return  &DataColors::getDeltaTemperaturesColor;
+		case GRB_CLOUD_TOT :        return &DataColors::getCloudColor;
 		case GRB_PRECIP_TOT :
         case GRB_PRECIP_RATE  :
-            function_getColor = &DataColors::getRainColor;
-			break;
-		case GRB_HUMID_REL :
-			function_getColor = &DataColors::getHumidColor;
-			break;
-		case GRB_TEMP :
-			function_getColor = &DataColors::getTemperatureColor;
-			break;
-		case GRB_TEMP_POT :
-			function_getColor = &DataColors::getTemperatureColor;
-			break;
-		case GRB_DEWPOINT :
-			function_getColor = &DataColors::getTemperatureColor;
-			break;
-		case GRB_SNOW_DEPTH :
-			function_getColor = &DataColors::getSnowDepthColor;
-			break;
-		case GRB_SNOW_CATEG :
-			function_getColor = &DataColors::getBinaryColor;
-			break;
-		case GRB_FRZRAIN_CATEG :
-			function_getColor = &DataColors::getBinaryColor;
-			break;
-		case GRB_CAPE :
-			function_getColor = &DataColors::getCAPEColor;
-			break;
-		case GRB_CIN :
-			function_getColor = &DataColors::getCINColor;
-			break;
-        // added by david
-        case GRB_COMP_REFL :
-            function_getColor = &DataColors::getReflectColor;
-            break;
+            return &DataColors::getRainColor;
+		case GRB_HUMID_REL :     return &DataColors::getHumidColor;
+		case GRB_TEMP :          return &DataColors::getTemperatureColor;
+		case GRB_TEMP_POT :      return &DataColors::getTemperatureColor;
+		case GRB_DEWPOINT :      return &DataColors::getTemperatureColor;
+		case GRB_SNOW_DEPTH :    return &DataColors::getSnowDepthColor;
+		case GRB_SNOW_CATEG :    return &DataColors::getBinaryColor;
+		case GRB_FRZRAIN_CATEG : return &DataColors::getBinaryColor;
+		case GRB_CAPE :          return &DataColors::getCAPEColor;
+		case GRB_CIN :           return &DataColors::getCINColor;
+        case GRB_COMP_REFL :     return &DataColors::getReflectColor;
 		case GRB_WAV_SIG_HT :
 		case GRB_WAV_MAX_HT :
-			function_getColor = &DataColors::getWaveHeightColor;
-			break;
-		case GRB_WAV_WHITCAP_PROB :
-			function_getColor = &DataColors::getWhiteCapColor;
+			return &DataColors::getWaveHeightColor;
+		case GRB_WAV_WHITCAP_PROB : return &DataColors::getWhiteCapColor;
 			break;
 		default :
-			function_getColor = &DataColors::getWindColor;	// why not
 			break;
 	}
+	return &DataColors::getWindColor;	// why not
+}
+
+//--------------------------------------------------------------------------
+void DataColors::setColorDataTypeFunction (const DataCode &dtc)
+{
+	function_getColor = getFunctionColor(dtc);
 }
  
 //--------------------------------------------------------------------------
 QRgb DataColors::getDataCodeColor (const DataCode &dtc, double v, bool smooth)
 {
-	switch (dtc.dataType) {
-		case GRB_WIND_GUST :
-			return DataColors::getGustColor (v, smooth);
-		case GRB_WIND_SPEED :
-		case GRB_PRV_WIND_XY2D :
-			return DataColors::getWindColor (v, smooth);
-		case GRB_PRV_WIND_JET :
-			return DataColors::getWindJetColor (v, smooth);
-		case GRB_PRV_THETA_E :
-			return DataColors::getThetaEColor (v, smooth);
-		case GRB_CUR_SPEED :
-		case GRB_PRV_CUR_XY2D :
-			return DataColors::getCurrentColor (v, smooth);
-		case GRB_PRV_DIFF_TEMPDEW :
-			return DataColors::getDeltaTemperaturesColor (v, smooth);
-		case GRB_CLOUD_TOT : 
-			return DataColors::getCloudColor (v, smooth);
-		case GRB_PRECIP_TOT :
-        case GRB_PRECIP_RATE  :
-            return DataColors::getRainColor (v, smooth);
-		case GRB_HUMID_REL :
-			return DataColors::getHumidColor (v, smooth);
-		case GRB_TEMP :
-			return DataColors::getTemperatureColor (v, smooth);
-		case GRB_TEMP_POT :
-			return DataColors::getTemperatureColor (v, smooth);
-		case GRB_DEWPOINT :
-			return DataColors::getTemperatureColor (v, smooth);
-		case GRB_SNOW_DEPTH :
-			return DataColors::getSnowDepthColor (v, smooth);
-		case GRB_SNOW_CATEG :
-			return DataColors::getBinaryColor (v, smooth);
-		case GRB_FRZRAIN_CATEG :
-			return DataColors::getBinaryColor (v, smooth);
-		case GRB_CAPE :
-			return DataColors::getCAPEColor (v, smooth);
-		case GRB_CIN :
-			return DataColors::getCINColor (v, smooth);
-        // added by david
-        case GRB_COMP_REFL :
-            return DataColors::getReflectColor (v, smooth);
-		case GRB_WAV_SIG_HT :
-		case GRB_WAV_MAX_HT :
-			return DataColors::getWaveHeightColor (v, smooth);
-		case GRB_WAV_WHITCAP_PROB :
-			return DataColors::getWhiteCapColor (v, smooth);
-		default :
-			return DataColors::getWindColor (v, smooth);	// why not
-	}
+	QRgb (DataColors::*fn) (double v, bool smooth);
+	fn = getFunctionColor(dtc);
+	return (this->*fn)(v, smooth);
 }
 
 //--------------------------------------------------------------------------
@@ -380,12 +304,3 @@ ColorScale *DataColors::getColorScale (const DataCode &dtc)
 			return &colors_Wind;
 	}
 }
-
-					
-
-
-
-
-
-
-

--- a/src/DataColors.h
+++ b/src/DataColors.h
@@ -94,6 +94,8 @@ class DataColors    // inherited by GriddedPlotter
 		QRgb  pasteToWindColorScale (double v, double min, double max, bool smooth);
 		
 		QRgb (DataColors::*function_getColor) (double v, bool smooth);
+	private:
+		auto getFunctionColor(const DataCode &dtc) -> QRgb (DataColors::*)(double v, bool smooth);
 };
 
 #endif

--- a/src/DataDefines.h
+++ b/src/DataDefines.h
@@ -22,6 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define GRIB_NOTDEF -99999
 
+using data_t = double;
+
 template <typename T> inline bool GribDataIsDef(T n) { return n != GRIB_NOTDEF;}
 
 enum DataCenterModel {

--- a/src/DataPointInfo.cpp
+++ b/src/DataPointInfo.cpp
@@ -201,6 +201,14 @@ DataPointInfo::DataPointInfo (GriddedReader *reader,
 			cx = -si;
 			cy = -co;
 		}
+		if (GribDataIsDef(currentDir)) {
+			// XXX I convert UV this way but what about other?
+			currentDir -= 180.;
+			if (currentDir < 0.)
+				currentDir += 360.;
+			if (currentDir >= 360.)
+				currentDir -=360.;
+		}
 	}
 	//-------------------------------------------------------------
 	// Data in altitude

--- a/src/Grib2Reader.cpp
+++ b/src/Grib2Reader.cpp
@@ -191,11 +191,16 @@ void Grib2Reader::analyseRecords ()
 	// Make a speed wind gust record from a vx and a vy records
 	// TODO : display also gust direction
 	Altitude alt (LV_ABOV_GND, 10);
+	if (hasData(DataCode(GRB_WIND_GUST, alt)))
+		return;
+
 	DataCode dtcx (GRB_WIND_GUST_VX, alt);
 	DataCode dtcy (GRB_WIND_GUST_VY, alt);
-	if (hasData(dtcx) && ! hasData(DataCode(GRB_WIND_GUST, alt))) {
-		for (long date : setAllDates)
-		{
+	if (!hasData(dtcx) || !hasData(dtcy))
+		return;
+
+	for (long date : setAllDates)
+	{
             GribRecord *recx = getRecord (dtcx, date);
 			GribRecord *recy = getRecord (dtcy, date);
 			if (recx && recy) {
@@ -219,7 +224,6 @@ void Grib2Reader::analyseRecords ()
 				storeRecordInMap (recGust);
 				//recGust->print("recGust");
 			}
-		}
 	}
 }
 

--- a/src/Grib2Record.cpp
+++ b/src/Grib2Record.cpp
@@ -113,8 +113,8 @@ Grib2Record::Grib2Record (gribfield  *gfld, int id, int idCenter, time_t refDate
 	// Data
 	//----------------------------------------
 	size_t size = Ni*Nj;
-	this->data = new double[size];
-	assert (this->data);
+	auto ptr = new double[size];
+    this->data = std::shared_ptr<double>(ptr, std::default_delete<double[]>());
 
     // Read data in the order given by isAdjacentI
     int i, j;
@@ -129,10 +129,10 @@ Grib2Record::Grib2Record (gribfield  *gfld, int id, int idCenter, time_t refDate
                     ind = j*Ni+i;
                 }
                 if (!hasBMS || gfld->bmap[ind]) {
-                    data[ind] = gfld->fld[indgfld];
+                    data.get()[ind] = gfld->fld[indgfld];
                 }
                 else {
-                    data[ind] = GRIB_NOTDEF;
+                    data.get()[ind] = GRIB_NOTDEF;
                 }
             }
         }
@@ -147,10 +147,10 @@ Grib2Record::Grib2Record (gribfield  *gfld, int id, int idCenter, time_t refDate
                     ind = j*Ni+i;
                 }
                 if (!hasBMS || gfld->bmap[ind]) {
-                    data[ind] = gfld->fld[indgfld];
+                    data.get()[ind] = gfld->fld[indgfld];
                 }
                 else {
-                    data[ind] = GRIB_NOTDEF;
+                    data.get()[ind] = GRIB_NOTDEF;
                 }
             }
         }

--- a/src/Grib2Record.cpp
+++ b/src/Grib2Record.cpp
@@ -155,6 +155,8 @@ Grib2Record::Grib2Record (gribfield  *gfld, int id, int idCenter, time_t refDate
             }
         }
     }
+#if 0
+	// don't keep BMS around nothing is using it (GRIB_NOTDEF)
 	if (ok && hasBMS) { // replace the BMS bits table with a faster bool table
         boolBMStab = new bool [Ni*Nj];
 		assert (boolBMStab);
@@ -165,6 +167,7 @@ Grib2Record::Grib2Record (gribfield  *gfld, int id, int idCenter, time_t refDate
 			}
 		}
 	}
+#endif
 	//----------------------------------------
 	// end
 	//----------------------------------------

--- a/src/Grib2Record.cpp
+++ b/src/Grib2Record.cpp
@@ -113,8 +113,8 @@ Grib2Record::Grib2Record (gribfield  *gfld, int id, int idCenter, time_t refDate
 	// Data
 	//----------------------------------------
 	size_t size = Ni*Nj;
-	auto ptr = new double[size];
-    this->data = std::shared_ptr<double>(ptr, std::default_delete<double[]>());
+	auto ptr = new data_t[size];
+    this->data = std::shared_ptr<data_t>(ptr, std::default_delete<data_t[]>());
 
     // Read data in the order given by isAdjacentI
     int i, j;

--- a/src/GribPlot.cpp
+++ b/src/GribPlot.cpp
@@ -522,33 +522,38 @@ void GribPlot::draw_WAVES_Arrows (
     if (!isReaderOk() || dtc.dataType == GRB_TYPE_NOT_DEFINED)
         return;
     QColor waveArrowColor (0,0,0);
-    GribRecord *recDir, *recPer;
+    GribRecord *recDir, *recPer, *recHt;
+    recDir = nullptr;
+    recPer = nullptr;
+    recHt  = nullptr;
+
 	if (dtc.dataType == GRB_PRV_WAV_SIG) {
 		recDir = gribReader->getRecord (DataCode(GRB_WAV_DIR,LV_GND_SURF,0), currentDate);
-//		recPer = gribReader->getRecord (DataCode(GRB_WAV__PER,LV_GND_SURF,0), currentDate);
+		recPer = gribReader->getRecord (DataCode(GRB_WAV_PER,LV_GND_SURF,0), currentDate);
+		recHt  = gribReader->getRecord (DataCode(GRB_WAV_SIG_HT,LV_GND_SURF,0), currentDate);
 	}
 	else if (dtc.dataType == GRB_PRV_WAV_PRIM) {
 		recDir = gribReader->getRecord (DataCode(GRB_WAV_PRIM_DIR,LV_GND_SURF,0), currentDate);
-//		recPer = gribReader->getRecord (DataCode(GRB_WAV_PRIM_PER,LV_GND_SURF,0), currentDate);
+		recPer = gribReader->getRecord (DataCode(GRB_WAV_PRIM_PER,LV_GND_SURF,0), currentDate);
 	}
 	else if (dtc.dataType == GRB_PRV_WAV_SCDY) {
 		recDir = gribReader->getRecord (DataCode(GRB_WAV_SCDY_DIR,LV_GND_SURF,0), currentDate);
-//		recPer = gribReader->getRecord (DataCode(GRB_WAV_SCDY_PER,LV_GND_SURF,0), currentDate);
+		recPer = gribReader->getRecord (DataCode(GRB_WAV_SCDY_PER,LV_GND_SURF,0), currentDate);
 	}
 	else if (dtc.dataType == GRB_PRV_WAV_MAX) {
 		recDir = gribReader->getRecord (DataCode(GRB_WAV_MAX_DIR,LV_GND_SURF,0), currentDate);
-//		recPer = gribReader->getRecord (DataCode(GRB_WAV_MAX_PER,LV_GND_SURF,0), currentDate);
+		recPer = gribReader->getRecord (DataCode(GRB_WAV_MAX_PER,LV_GND_SURF,0), currentDate);
+		recHt  = gribReader->getRecord (DataCode(GRB_WAV_MAX_HT,LV_GND_SURF,0), currentDate);
 	}
 	else if (dtc.dataType == GRB_PRV_WAV_SWL) {
 		recDir = gribReader->getRecord (DataCode(GRB_WAV_SWL_DIR,LV_GND_SURF,0), currentDate);
-//		recPer = gribReader->getRecord (DataCode(GRB_WAV_SWL_PER,LV_GND_SURF,0), currentDate);
+		recPer = gribReader->getRecord (DataCode(GRB_WAV_SWL_PER,LV_GND_SURF,0), currentDate);
+		recHt  = gribReader->getRecord (DataCode(GRB_WAV_SWL_HT,LV_GND_SURF,0), currentDate);
 	}
 	else if (dtc.dataType == GRB_PRV_WAV_WND) {
 		recDir = gribReader->getRecord (DataCode(GRB_WAV_WND_DIR,LV_GND_SURF,0), currentDate);
-//		recPer = gribReader->getRecord (DataCode(GRB_WAV_WND_PER,LV_GND_SURF,0), currentDate);
-	}
-	else {
-        recDir = recPer = nullptr;
+		recPer = gribReader->getRecord (DataCode(GRB_WAV_WND_PER,LV_GND_SURF,0), currentDate);
+		recHt   = gribReader->getRecord (DataCode(GRB_WAV_WND_HT,LV_GND_SURF,0), currentDate);
 	}
 //    if (recDir==NULL || recPer==NULL)
     if (recDir==nullptr)
@@ -587,9 +592,12 @@ void GribPlot::draw_WAVES_Arrows (
                                 vxy = recDir->getInterpolatedValue(x, y, mustInterpolateValues);
 //                                vy = recPer->getInterpolatedValue(x, y, mustInterpolateValues);
 //                                if (vxy != GRIB_NOTDEF && vy != GRIB_NOTDEF)
-                                if (GribDataIsDef(vxy))
-                                {
+                                if (GribDataIsDef(vxy)) {
 //                                    drawWaveArrow (pnt, i,j, vxy,vy);
+                                    if (recHt && recHt->getInterpolatedValue(x, y, mustInterpolateValues) < 0.01)
+                                    	continue;
+                                    if (recPer && recPer->getInterpolatedValue(x, y, mustInterpolateValues) < 0.01)
+                                    	continue;
                                     drawWaveArrow (pnt, i,j, vxy);
                                 }
 							}
@@ -614,6 +622,10 @@ void GribPlot::draw_WAVES_Arrows (
                     if (GribDataIsDef(vxy))
 					{
 //                        drawWaveArrow (pnt, i,j, vx,vy);
+                        if (recHt && recHt->getInterpolatedValue(x, y, mustInterpolateValues) < 0.01)
+                        	continue;
+                        if (recPer && recPer->getInterpolatedValue(x, y, mustInterpolateValues) < 0.01)
+                        	continue;
                         drawWaveArrow (pnt, i,j, vxy);
                     }
 				}

--- a/src/GribReader.cpp
+++ b/src/GribReader.cpp
@@ -489,7 +489,7 @@ void  GribReader::copyFirstCumulativeRecord (DataCode dtc)
 		rec = getFirstGribRecord (dtc);
 		if (rec != nullptr)
 		{
-			GribRecord *r2 = new GribRecord (*rec);
+			GribRecord *r2 = new GribRecord (*rec, false);
 			r2->setRecordCurrentDate (dateref);    // 1er enregistrement factice
 			storeRecordInMap (r2);
 		}
@@ -515,7 +515,7 @@ void  GribReader::copyMissingWaveRecords (DataCode dtc)
 			if (rec2) {
 				if (!rec2->isDuplicated()) {
 					// create a copied record from date2
-					GribRecord *r2 = new GribRecord (*rec2);
+					GribRecord *r2 = new GribRecord (*rec2, false);
 					r2->setRecordCurrentDate (date);
 					storeRecordInMap (r2);
 				}

--- a/src/GribRecord.cpp
+++ b/src/GribRecord.cpp
@@ -557,11 +557,11 @@ GribRecord::GribRecord (const GribRecord &rec, bool copy)
 	setDuplicated (true);
     if (rec.data != nullptr && copy) {
         int size = rec.Ni*rec.Nj;
-        auto ptr = new double[size];
+        auto ptr = new data_t[size];
         for (int i=0; i<size; i++) {
             ptr[i] = rec.data.get()[i];
         }
-        this->data = std::shared_ptr<double>(ptr, std::default_delete<double[]>());
+        this->data = std::shared_ptr<data_t>(ptr, std::default_delete<data_t[]>());
     }
 
     // recopie les champs de bits
@@ -634,7 +634,7 @@ void  GribRecord::checkOrientation ()
 void GribRecord::reverseData (char orientation) // orientation = 'H' or 'V'
 {
 	int i, j, i1, j1, i2, j2;
-	double v;
+	data_t v;
 	bool b;
 	if (orientation == 'H') 
 	{
@@ -689,8 +689,9 @@ uint64_t GribRecord::makeKey(int dataType,int levelType,int levelValue)
     return (((static_cast<uint64_t>(dataType) << 16) | static_cast<uint64_t>(levelType)) << 32) | levelValue;
 }
 //-------------------------------------------------------------------------------
-void  GribRecord::multiplyAllData(double k)
+void  GribRecord::multiplyAllData(double val)
 {
+    data_t k = val;
 	for (int j=0; j<Nj; j++) {
 		for (int i=0; i<Ni; i++)
 		{
@@ -1022,8 +1023,8 @@ bool GribRecord::readGribSection4_BDS(ZUFILE* file) {
     }
 
     // Allocate memory for the data
-	auto ptr = new double[Ni*Nj];
-    data = std::shared_ptr<double>(ptr, std::default_delete<double[]>());
+	auto ptr = new data_t[Ni*Nj];
+    data = std::shared_ptr<data_t>(ptr, std::default_delete<data_t[]>());
     if (!data) {
         erreur("Record %d: out of memory",id);
         ok = false;
@@ -1289,7 +1290,7 @@ zuint GribRecord::periodSeconds(zuchar unit,zuchar P1,zuchar P2,zuchar range) {
 
 
 //===============================================================================================
-double GribRecord::getInterpolatedValue (double px, double py, bool interpolate) const
+data_t GribRecord::getInterpolatedValue (double px, double py, bool interpolate) const
 {
     double val; 
 	double eps = 1e-4;
@@ -1466,14 +1467,14 @@ double GribRecord::getInterpolatedValue (double px, double py, bool interpolate)
     return val;
 }
 //--------------------------------------------------------------------------
-double GribRecord::getValueOnRegularGrid (DataCode dtc, int i, int j ) const
+data_t GribRecord::getValueOnRegularGrid (DataCode dtc, int i, int j ) const
 {
 	if ( getDataCode() != dtc )
 		return GRIB_NOTDEF;
     return getValue (i,j);
 }
 //--------------------------------------------------------------------------
-double  GribRecord::getInterpolatedValue (
+data_t  GribRecord::getInterpolatedValue (
 						DataCode dtc,
 						double px, double py,
 						bool interpolate) const 

--- a/src/GribRecord.cpp
+++ b/src/GribRecord.cpp
@@ -551,18 +551,20 @@ GribRecord::GribRecord (ZUFILE* file, int id_)
 //-------------------------------------------------------------------------------
 // Constructeur de recopie
 //-------------------------------------------------------------------------------
-GribRecord::GribRecord (const GribRecord &rec)
+GribRecord::GribRecord (const GribRecord &rec, bool copy)
 {
     *this = rec;
 	setDuplicated (true);
-    // recopie les champs de bits
-    if (rec.data != nullptr) {
+    if (rec.data != nullptr && copy) {
         int size = rec.Ni*rec.Nj;
-        this->data = new double[size];
-		assert (this->data);
-        for (int i=0; i<size; i++)
-            this->data[i] = rec.data[i];
+        auto ptr = new double[size];
+        for (int i=0; i<size; i++) {
+            ptr[i] = rec.data.get()[i];
+        }
+        this->data = std::shared_ptr<double>(ptr, std::default_delete<double[]>());
     }
+
+    // recopie les champs de bits
     if (rec.BMSbits != nullptr) {
         int size = rec.sectionSize3-6;
         this->BMSbits = new zuchar[size];
@@ -582,7 +584,6 @@ GribRecord::GribRecord (const GribRecord &rec)
 //--------------------------------------------------------------------------
 GribRecord::~GribRecord()
 {
-    delete [] data;
     delete [] BMSbits;
     delete [] boolBMStab;
 }
@@ -640,9 +641,9 @@ void GribRecord::reverseData (char orientation) // orientation = 'H' or 'V'
 		for (j=0; j<Nj; j++) {
 			for (i1=0,i2=Ni-1;  i1<i2;  i1++,i2--) // Reverse line j
 			{
-				v = data [j*Ni+i1];
-				data [j*Ni+i1] = data [j*Ni+i2];
-				data [j*Ni+i2] = v;
+				v = data.get() [j*Ni+i1];
+				data.get() [j*Ni+i1] = data.get() [j*Ni+i2];
+				data.get() [j*Ni+i2] = v;
 				if (boolBMStab) {
 					b = boolBMStab [j*Ni+i1];
 					boolBMStab [j*Ni+i1] = boolBMStab [j*Ni+i2];
@@ -656,9 +657,9 @@ void GribRecord::reverseData (char orientation) // orientation = 'H' or 'V'
 		for (i=0; i<Ni; i++) {
 			for (j1=0,j2=Nj-1;  j1<j2;  j1++,j2--) // Reverse row i
 			{
-				v = data [j1*Ni+i];
-				data [j1*Ni+i] = data [j2*Ni+i];
-				data [j2*Ni+i] = v;
+				v = data.get() [j1*Ni+i];
+				data.get() [j1*Ni+i] = data.get() [j2*Ni+i];
+				data.get() [j2*Ni+i] = v;
 				if (boolBMStab) {
 					b = boolBMStab [j1*Ni+i];
 					boolBMStab [j1*Ni+i] = boolBMStab [j2*Ni+i];
@@ -694,7 +695,7 @@ void  GribRecord::multiplyAllData(double k)
 		for (int i=0; i<Ni; i++)
 		{
 			if (hasValue(i,j)) {
-				data[j*Ni+i] *= k;
+				data.get()[j*Ni+i] *= k;
 			}
 		}
 	}
@@ -734,12 +735,12 @@ void GribRecord::average(const GribRecord &rec)
     zuint size = Ni *Nj;
     double diff = d2 -d1;
     for (zuint i=0; i<size; i++) {
-        if (! GribDataIsDef(rec.data[i]))
+        if (! GribDataIsDef(rec.data.get()[i]))
            continue;
-        if (! GribDataIsDef(data[i]))
+        if (! GribDataIsDef(data.get()[i]))
            continue;
 
-        data[i] = (data[i]*d2 -rec.data[i]*d1)/diff;
+        data.get()[i] = (data.get()[i]*d2 -rec.data.get()[i]*d1)/diff;
     }
 }
 
@@ -758,20 +759,20 @@ void GribRecord::substract(const GribRecord &rec, bool pos)
 
     zuint size = Ni *Nj;
     for (zuint i=0; i<size; i++) {
-        if (rec.data[i] == GRIB_NOTDEF)
+        if (rec.data.get()[i] == GRIB_NOTDEF)
            continue;
-        if (! GribDataIsDef(data[i])) {
-            data[i] = -rec.data[i];
+        if (! GribDataIsDef(data.get()[i])) {
+            data.get()[i] = -rec.data.get()[i];
             // XXX BMSbits
             if (boolBMStab) {
                 boolBMStab [i] = true;
             }
         }
         else
-            data[i] -= rec.data[i];
-        if (data[i] < 0. && pos) {
+            data.get()[i] -= rec.data.get()[i];
+        if (pos && data.get()[i] < 0.) {
             // clamp data ...
-            data[i] = 0.;
+            data.get()[i] = 0.;
         }
     }
 }
@@ -1021,7 +1022,8 @@ bool GribRecord::readGribSection4_BDS(ZUFILE* file) {
     }
 
     // Allocate memory for the data
-    data = new double[Ni*Nj];
+	auto ptr = new double[Ni*Nj];
+    data = std::shared_ptr<double>(ptr, std::default_delete<double[]>());
     if (!data) {
         erreur("Record %d: out of memory",id);
         ok = false;
@@ -1060,11 +1062,11 @@ bool GribRecord::readGribSection4_BDS(ZUFILE* file) {
                 }
                 if (hasValueInBitBMS(i,j)) {
                     x = readPackedBits(buf, startbit, nbBitsInPack);
-                    data[ind] = (refValue + x*scaleFactorEpow2)/decimalFactorD;
+                    data.get()[ind] = (refValue + x*scaleFactorEpow2)/decimalFactorD;
                     startbit += nbBitsInPack;
                 }
                 else {
-                    data[ind] = GRIB_NOTDEF;
+                    data.get()[ind] = GRIB_NOTDEF;
                 }
             }
         }
@@ -1081,10 +1083,10 @@ bool GribRecord::readGribSection4_BDS(ZUFILE* file) {
                 if (hasValueInBitBMS(i,j)) {
                     x = readPackedBits(buf, startbit, nbBitsInPack);
                     startbit += nbBitsInPack;
-                    data[ind] = (refValue + x*scaleFactorEpow2)/decimalFactorD;
+                    data.get()[ind] = (refValue + x*scaleFactorEpow2)/decimalFactorD;
                 }
                 else {
-                    data[ind] = GRIB_NOTDEF;
+                    data.get()[ind] = GRIB_NOTDEF;
                 }
             }
         }

--- a/src/GribRecord.h
+++ b/src/GribRecord.h
@@ -33,12 +33,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define debug(format, ...)  {if(DEBUG_INFO)  {fprintf(stderr,format,__VA_ARGS__);fprintf(stderr,"\n");}}
 #define erreur(format, ...) {if(DEBUG_ERROR) {fprintf(stderr,"ERROR: ");fprintf(stderr,format,__VA_ARGS__);fprintf(stderr,"\n");}}
 
-#define zuint  uint32_t
-#define zuchar uint8_t
+using zuint = uint32_t;
+using zuchar = uint8_t;
 
 //----------------------------------------------
 class GribRecord : public RegularGridRecord  
-{ 
+{
     public:
         GribRecord () = default;
         GribRecord (ZUFILE* file, int id_);
@@ -103,20 +103,20 @@ class GribRecord : public RegularGridRecord
             }
 
         // Valeur pour un point de la grille
-        double getValue (int i, int j) const 
+        data_t getValue (int i, int j) const 
 							{ return ok && i>=0 && i<Ni && j>=0 && j<Nj ? data.get()[j*Ni+i] : GRIB_NOTDEF;}
 		
         // Valeur pour un point quelconque
-        double  getInterpolatedValue (
+        data_t  getInterpolatedValue (
 							double px, double py,
 							bool interpolate=true) const;
 
-		double  getInterpolatedValue (
+		data_t  getInterpolatedValue (
 							DataCode dtc,
 							double px, double py,
 							bool interpolate=true ) const override;
 		 
-        double getValueOnRegularGrid (
+        data_t getValueOnRegularGrid (
 						DataCode dtc, int i, int j ) const override;
 
         void setValue (int i, int j, double v)
@@ -210,7 +210,7 @@ class GribRecord : public RegularGridRecord
         double scaleFactorEpow2;
         double refValue;
         zuint  nbBitsInPack;
-        std::shared_ptr<double> data;
+        std::shared_ptr<data_t> data;
         // SECTION 5: END SECTION (ES)
 
         //---------------------------------------------

--- a/src/GribRecord.h
+++ b/src/GribRecord.h
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <cmath>
 #include <stdint.h>
 #include <cstdint>
+#include <memory>
 
 #include "zuFile.h"
 #include "RegularGridded.h"
@@ -41,7 +42,7 @@ class GribRecord : public RegularGridRecord
     public:
         GribRecord () = default;
         GribRecord (ZUFILE* file, int id_);
-        GribRecord (const GribRecord &rec);
+        GribRecord (const GribRecord &rec, bool copy = true);
         ~GribRecord ();
 
         void   multiplyAllData(double k);
@@ -103,7 +104,7 @@ class GribRecord : public RegularGridRecord
 
         // Valeur pour un point de la grille
         double getValue (int i, int j) const 
-							{ return ok && i>=0 && i<Ni && j>=0 && j<Nj ? data[j*Ni+i] : GRIB_NOTDEF;}
+							{ return ok && i>=0 && i<Ni && j>=0 && j<Nj ? data.get()[j*Ni+i] : GRIB_NOTDEF;}
 		
         // Valeur pour un point quelconque
         double  getInterpolatedValue (
@@ -120,7 +121,7 @@ class GribRecord : public RegularGridRecord
 
         void setValue (int i, int j, double v)
         		{ if (i>=0 && i<Ni && j>=0 && j<Nj)
-        			data[j*Ni+i] = v; }
+        			data.get()[j*Ni+i] = v; }
 
         // La valeur est-elle définie (grille à trous) ?
         inline bool   hasValue (int i, int j) const;
@@ -209,7 +210,7 @@ class GribRecord : public RegularGridRecord
         double scaleFactorEpow2;
         double refValue;
         zuint  nbBitsInPack;
-        double  *data{};
+        std::shared_ptr<double> data;
         // SECTION 5: END SECTION (ES)
 
         //---------------------------------------------
@@ -268,7 +269,7 @@ inline bool   GribRecord::hasValue (int i, int j) const
         return false;
     }
     if (boolBMStab == nullptr) {
-        return data[j*Ni+i] != GRIB_NOTDEF;
+        return data.get()[j*Ni+i] != GRIB_NOTDEF;
     }
 	return boolBMStab [j*Ni+i];
 }

--- a/src/GriddedRecord.cpp
+++ b/src/GriddedRecord.cpp
@@ -31,7 +31,7 @@ GriddedRecord::GriddedRecord ()
 //=====================================================================
 // Interpolation using a regular rectangular grid
 //=====================================================================
-double  GriddedRecord::getInterpolatedValueUsingRegularGrid (
+data_t  GriddedRecord::getInterpolatedValueUsingRegularGrid (
 				DataCode dtc, 
 				double px, double py,
 				bool interpolateValues) const

--- a/src/GriddedRecord.h
+++ b/src/GriddedRecord.h
@@ -51,7 +51,7 @@ class GriddedRecord : public DataRecordAbstract
         virtual bool isPointInMap(double x, double y) const
 						{ return isXInMap(x) && isYInMap(y); }
 
-        virtual double  getInterpolatedValue (
+        virtual data_t  getInterpolatedValue (
 							DataCode dtc,
 							double px, double py,
 							bool interpolate=true ) const = 0;
@@ -62,9 +62,9 @@ class GriddedRecord : public DataRecordAbstract
 		
 		/** All records must have (or simulate) a rectangular regular grid.
 		*/ 
-		virtual double getValueOnRegularGrid ( 
+		virtual data_t getValueOnRegularGrid ( 
 								DataCode dtc, int i, int j ) const = 0;
-		virtual double  getInterpolatedValueUsingRegularGrid (
+		virtual data_t  getInterpolatedValueUsingRegularGrid (
 								DataCode dtc, 
 								double px, double py,
 								bool interpolateValues) const;

--- a/src/MeteoTableWidget.cpp
+++ b/src/MeteoTableWidget.cpp
@@ -699,7 +699,7 @@ void MeteoTableWidget::addLine_DeltaTemperature(const Altitude &alt, uchar type,
 			break;
 	}
 	col ++;
-	for (iter=lspinfos.begin(); iter!=lspinfos.end(); iter++, col++)
+	for (iter=lspinfos.begin(); iter!=lspinfos.end(); ++iter, col++)
 	{
 		DataPointInfo * pinfo = *iter;
 		switch (type) {
@@ -728,7 +728,7 @@ void MeteoTableWidget::addLine_DewPoint(const Altitude &alt, int lig)
 	addCell_title_dataline (tr("Dew point")+" ("+AltitudeStr::toStringShort(alt)+")", 
 				  true, lig,col);
 	col ++;
-	for (iter=lspinfos.begin(); iter!=lspinfos.end(); iter++, col++)
+	for (iter=lspinfos.begin(); iter!=lspinfos.end(); ++iter, col++)
 	{
 		DataPointInfo * pinfo = *iter;
 		txt = "";
@@ -751,14 +751,13 @@ void MeteoTableWidget::addLine_CAPEsfc (int lig)
 	int col = 0;
 	addCell_title_dataline (tr("CAPE (surface)"), true, lig,col);
 	col ++;
-	for (iter=lspinfos.begin(); iter!=lspinfos.end(); iter++, col++)
+	for (iter=lspinfos.begin(); iter!=lspinfos.end(); ++iter, col++)
 	{
 		DataPointInfo * pinfo = *iter;
 		txt = "";
 		if (pinfo->hasCAPEsfc()) {
 			double v = pinfo->CAPEsfc;
-			txt.sprintf("%d ", qRound(v));
-			txt += tr("J/kg");
+			txt = Util::formatCAPEsfc(v);
 			bgColor = QColor(plotter->getCAPEColor(v, true));
 		}
 		else
@@ -775,14 +774,13 @@ void MeteoTableWidget::addLine_CINsfc (int lig)
     int col = 0;
     addCell_title_dataline (tr("CIN (surface)"), true, lig,col);
     col ++;
-    for (iter=lspinfos.begin(); iter!=lspinfos.end(); iter++, col++)
+    for (iter=lspinfos.begin(); iter!=lspinfos.end(); ++iter, col++)
     {
         DataPointInfo * pinfo = *iter;
         txt = "";
         if (pinfo->hasCINsfc()) {
             double v = pinfo->CINsfc;
-            txt.sprintf("%d ", qRound(v));
-            txt += tr("J/kg");
+			txt = Util::formatCAPEsfc(v);
             bgColor = QColor(plotter->getCINColor(v, true));
         }
         else
@@ -799,14 +797,13 @@ void MeteoTableWidget::addLine_Reflectivity (int lig)
     int col = 0;
     addCell_title_dataline (tr("Reflectivity (entire atmos)"), true, lig,col);
     col ++;
-    for (iter=lspinfos.begin(); iter!=lspinfos.end(); iter++, col++)
+    for (iter=lspinfos.begin(); iter!=lspinfos.end(); ++iter, col++)
     {
         DataPointInfo * pinfo = *iter;
         txt = "";
         if (pinfo->hasCompReflect()) {
             double v = pinfo->compReflect;
-            txt.sprintf("%d ", qRound(v));
-            txt += tr("dBZ");
+            txt = Util::formatReflect(v);
             bgColor = QColor(plotter->getReflectColor(v, true));
         }
         else
@@ -823,7 +820,7 @@ void MeteoTableWidget::addLine_Rain(int lig)
 	int col = 0;
 	addCell_title_dataline (tr("Precipitation"), true, lig,col);
 	col ++;
-	for (iter=lspinfos.begin(); iter!=lspinfos.end(); iter++, col++)
+	for (iter=lspinfos.begin(); iter!=lspinfos.end(); ++iter, col++)
 	{
 		DataPointInfo * pinfo = *iter;
 		txt = "";
@@ -847,7 +844,7 @@ void MeteoTableWidget::addLine_CloudCover (int lig)
 	int col = 0;
 	addCell_title_dataline (tr("Cloud cover"), true, lig,col);
 	col ++;
-	for (iter=lspinfos.begin(); iter!=lspinfos.end(); iter++, col++)
+	for (iter=lspinfos.begin(); iter!=lspinfos.end(); ++iter, col++)
 	{
 		DataPointInfo * pinfo = *iter;
 		txt = "";
@@ -879,7 +876,7 @@ void MeteoTableWidget::addLine_Categorical (uchar type, int lig)
 			break;
 	}
 	col ++;
-	for (iter=lspinfos.begin(); iter!=lspinfos.end(); iter++, col++)
+	for (iter=lspinfos.begin(); iter!=lspinfos.end(); ++iter, col++)
 	{
 		DataPointInfo * pinfo = *iter;
 		switch (type) {
@@ -909,13 +906,12 @@ void MeteoTableWidget::addLine_SnowDepth (int lig)
 	double v = -1000;
 	addCell_title_dataline (tr("Snow"), true, lig,col);
 	col ++;
-	for (iter=lspinfos.begin(); iter!=lspinfos.end(); iter++, col++)
+	for (iter=lspinfos.begin(); iter!=lspinfos.end(); ++iter, col++)
 	{
 		DataPointInfo * pinfo = *iter;
 		v = pinfo->snowDepth;
 		txt = "";
 		if (v >= 0) {
-			txt.sprintf("%.2f", v);
 			txt = Util::formatSnowDepth(v);
 			bgColor = QColor(plotter->getSnowDepthColor(v, true));
 		}
@@ -931,7 +927,7 @@ void MeteoTableWidget::addLine_SkewT (int lig)
 	int col = 0;
 	addCell_title_dataline (tr("SkewT-LogP"), true, lig,col);
 	col ++;
-	for (iter=lspinfos.begin(); iter!=lspinfos.end(); iter++, col++)
+	for (iter=lspinfos.begin(); iter!=lspinfos.end(); ++iter, col++)
 	{
 		DataPointInfo *pinfo = *iter;
 		addCell_SkewT (layout,lig,col, pinfo->date);

--- a/src/g2clib-1.6.0/drstemplates.h
+++ b/src/g2clib-1.6.0/drstemplates.h
@@ -31,7 +31,7 @@
 //
 ///////////////////////////////////////////////////////////////////////
 
-      #define MAXDRSTEMP 9              // maximum number of templates
+      #define MAXDRSTEMP 10              // maximum number of templates
       #define MAXDRSMAPLEN 200          // maximum template map length
 
       struct drstemplate
@@ -49,6 +49,8 @@
          { 2, 16, 0, {4,-2,-2,1,1,1,1,4,4,4,1,1,4,1,4,1} },
              // 5.3: Grid point data - Complex Packing and spatial differencing
          { 3, 18, 0, {4,-2,-2,1,1,1,1,4,4,4,1,1,4,1,4,1,1,1} },
+             // 5.4: Grid point data - IEEE Floating Point Data
+         { 4, 1, 0, {1} },
              // 5.50: Spectral Data - Simple Packing
          { 50, 5, 0, {4,-2,-2,1,4} },
              // 5.51: Spherical Harmonics data - Complex packing 


### PR DESCRIPTION
Hi,

* Use users units everywhere.
* don't display arrow for waves with 0 height
* Add grib IEEE float encoding
* reduce memory footprint by:
  * using a shared ptr when copying records
  * Don't  keep BMS, the info is in the array  and it's big.

Regards
Didier
