### PR TITLE
Enable GFS Reflectivity in downloader Dialog

### DIFF
--- a/src/DialogLoadGRIB.cpp
+++ b/src/DialogLoadGRIB.cpp
@@ -480,6 +480,7 @@ void DialogLoadGRIB::slotAtmModelSettings()
         chkIsotherm0->setEnabled(true);
         chkCAPEsfc->setEnabled(true);
         chkCINsfc->setEnabled(true);
+        chkReflectivity->setEnabled(true);
         chkCloud->setEnabled(true);
         chkHumid->setEnabled(true);
         chkRain->setEnabled(true);
@@ -500,8 +501,6 @@ void DialogLoadGRIB::slotAtmModelSettings()
         chkAltitude_SkewT->setEnabled(true);
 
         // deactivate unvalid parameters
-        chkReflectivity->setEnabled(false); chkReflectivity->setChecked(false);
-
     }
     else if (amod == "ICON")
     {


### PR DESCRIPTION
Hi,

NOAA GFS Reflectivity is available since 2019-06-12 and OpenGrib server
has it.

Cf issue #213 

Regards
Didier
