### PR TITLE
Add params UGUST and VGUST for productnum 8 (accum)

### DIFF
--- a/src/Grib2Record.cpp
+++ b/src/Grib2Record.cpp
@@ -744,6 +744,10 @@ int Grib2Record::analyseProductType ()
         else if (paramcat==2) {
             if (paramnumber==22)
                 return GRB_WIND_GUST;
+            else if (paramnumber==23)
+                return GRB_WIND_GUST_VX;
+            else if (paramnumber==24)
+                return GRB_WIND_GUST_VY;
         }
 		else if (paramcat==6) {//TABLE 4.2-0-6
 			if (paramnumber==1)


### PR DESCRIPTION
KNMI HARMONIE has wind gusts as U-gust and V-gust, as maximum value over the previous hour. 
After conversion to GRIB2 these are parameters 23 and 24, in paramcat 2 (TABLE 4.2-0-2), with pdtnum 8.