### PR TITLE
Include <QPainterPath> - fixes compilation with gcc 10

### DIFF
--- a/src/SkewT.h
+++ b/src/SkewT.h
@@ -31,6 +31,7 @@
 #include <QCheckBox>
 #include <QThread>
 #include <QMessageBox>
+#include <QPainterPath>
 
 class SkewT;
 


### PR DESCRIPTION
XyGrib fails to compile with GCC 10.

https://opengribs.org/en/forum/xygrib-support/178-build-fail-against-qt-5-15-gcc10

This PR should fix this.