### PR TITLE
Speedup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_STANDARD 11)
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
 if(UNIX AND NOT APPLE)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fPIC -pg -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fPIC")
 endif()
 
 # Add support for address etc sanitizers, part 1/2 (other half after ADD_EXECUTABLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_STANDARD 11)
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
 if(UNIX AND NOT APPLE)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fPIC -pg -g")
 endif()
 
 # Add support for address etc sanitizers, part 1/2 (other half after ADD_EXECUTABLE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,9 +28,12 @@ FileLoader.h
 FileLoaderGRIB.h
 Grib2Record.h
 GribAnimator.h
+GribFile.h
 GribPlot.h
 GribReader.h
 GribRecord.h
+GribRecordBuffer.h
+GribRecordTask.h
 GriddedPlotter.h
 GriddedReader.h
 GriddedRecord.h
@@ -77,9 +80,12 @@ DialogUnits.cpp
 FileLoaderGRIB.cpp
 Grib2Record.cpp
 GribAnimator.cpp
+GribFile.cpp
 GribPlot.cpp
 GribReader.cpp
 GribRecord.cpp
+GribRecordBuffer.cpp
+GribRecordTask.cpp
 GriddedPlotter.cpp
 GriddedReader.cpp
 GriddedRecord.cpp

--- a/src/GribFile.cpp
+++ b/src/GribFile.cpp
@@ -1,0 +1,79 @@
+/**********************************************************************
+XyGrib: meteorological GRIB file viewer
+
+Copyright (C) 2020 - opengrib - http://www.xygrib.org
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***********************************************************************/
+
+#include "GribFile.h"
+#include <cstring>
+
+// start with 1mb chunks
+const int BUFFER_SIZE = 1 << 20;
+
+GribFile::GribFile (ZUFILE* file)
+    : num_bytes_(0)
+{
+    if (!retrieve(file))
+    {
+        delete [] grib_data_;
+        num_bytes_ = 0;
+    }
+}
+
+GribFile::~GribFile()
+{
+    delete [] grib_data_;
+}
+
+uint8_t GribFile::get(size_t idx) const
+{
+    if (idx >= num_bytes_)
+        return 0;
+    return grib_data_[idx];
+}
+
+bool GribFile::copy(uint8_t* buffer, size_t idx, size_t count) const
+{
+    if (idx + count >= num_bytes_)
+        return false;
+    std::memcpy(buffer, &grib_data_[idx], count);
+    return true;
+}
+
+bool GribFile::retrieve(ZUFILE *f)
+{
+    if (zu_seek(f, 0, SEEK_SET) != 0) {
+         return false;
+    }
+    grib_data_ = new uint8_t[BUFFER_SIZE];
+    int bytes_read = 0;
+    int count = 1;
+    do {
+        size_t offset = BUFFER_SIZE*(count-1);
+        bytes_read = zu_read(f, grib_data_+offset, BUFFER_SIZE);
+        num_bytes_ += bytes_read;
+        if (bytes_read == BUFFER_SIZE) {
+            uint8_t* newbuf = new uint8_t[BUFFER_SIZE * ++count];
+            std::memcpy(newbuf, grib_data_, BUFFER_SIZE*(count-1));
+            delete [] grib_data_;
+            grib_data_ = newbuf;
+        } else if (bytes_read < BUFFER_SIZE)
+            break;
+    }
+    while (bytes_read != 0);
+    return num_bytes_ > 0;
+}
+

--- a/src/GribFile.cpp
+++ b/src/GribFile.cpp
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "GribFile.h"
 #include <cstring>
 
-// start with 1mb chunks
+// read file in 1mb chunks
 const int BUFFER_SIZE = 1 << 20;
 
 GribFile::GribFile (ZUFILE* file)

--- a/src/GribFile.cpp
+++ b/src/GribFile.cpp
@@ -24,13 +24,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 const int BUFFER_SIZE = 1 << 20;
 
 GribFile::GribFile (ZUFILE* file)
-    : num_bytes_(0)
+    : num_bytes_(0), num_records_(0)
 {
     if (!retrieve(file))
     {
         delete [] grib_data_;
         num_bytes_ = 0;
     }
+    // count number of records
+    size_t iseek = 0;
+    find_record_result_t res;
+    do {
+        res = find_record(iseek);
+        if (res.record_length > 0)
+            num_records_++;
+        iseek += res.record_length;
+    } while (iseek < num_bytes_);
 }
 
 GribFile::~GribFile()
@@ -47,7 +56,7 @@ uint8_t GribFile::get(size_t idx) const
 
 bool GribFile::copy(uint8_t* buffer, size_t idx, size_t count) const
 {
-    if (idx + count >= num_bytes_)
+    if (idx + count > num_bytes_)
         return false;
     std::memcpy(buffer, &grib_data_[idx], count);
     return true;
@@ -75,5 +84,105 @@ bool GribFile::retrieve(ZUFILE *f)
     }
     while (bytes_read != 0);
     return num_bytes_ > 0;
+}
+
+enum parse_state_t {
+    START, G, R, I, B, LEN1, LEN2, LEN3, V, V2LEN1, V2LEN2, V2LEN3, V2LEN4, SEEKEND, FINISHED
+};
+
+find_record_result_t GribFile::find_record(size_t file_offset) const
+{
+    find_record_result_t res = {file_offset,0,0,0};
+
+    if (file_offset >= num_bytes_)
+        return res;
+    
+    bool finished = true;
+    uint32_t len = 0;
+    size_t i = 0;
+    enum parse_state_t parse_state = START;
+    while (parse_state != FINISHED && i <= num_bytes_ - file_offset) {
+        uint8_t ch = get(i + file_offset);
+        switch (parse_state) {
+        case START:
+            if (ch == 'G') {
+                parse_state = G;
+                res.record_start = i;
+            }
+            break;
+        case G:
+            parse_state = ch == 'R' ? R : START;
+            break;
+        case R:
+            parse_state = ch == 'I' ? I : START;
+            break;
+        case I:
+            parse_state = ch == 'B' ? B : START;
+            break;
+        case B:
+            len = ch << 16;
+            parse_state = LEN1;
+            break;
+        case LEN1:
+            len += ch << 8;
+            parse_state = LEN2;
+            break;
+        case LEN2:
+            len += ch;
+            parse_state = LEN3;
+            break;
+        case LEN3:
+            res.version = ch;
+            parse_state = V;
+            break;
+        case V:
+            if (res.version == 1) {
+                parse_state = SEEKEND;
+            }
+            else {
+                if (res.version == 2) {
+                    i = 11;
+                    parse_state = V2LEN1;
+                }
+                else
+                    parse_state = START;
+            }
+            break;
+        case V2LEN1:
+            len = ch << 24;
+            parse_state = V2LEN2;
+            break;
+        case V2LEN2:
+            len += ch << 16;
+            parse_state = V2LEN3;
+            break;
+        case V2LEN3:
+            len += ch << 8;
+            parse_state = V2LEN4;
+            break;
+        case V2LEN4:
+            len += ch;
+            parse_state = SEEKEND;
+            break;
+        case SEEKEND:
+            uint8_t eor[4];
+            parse_state = FINISHED;
+            if (!copy(eor, file_offset + res.record_start + len - 4, 4)
+                || eor[0] != '7' || eor[1] != '7' || eor[2] != '7' || eor[3] != '7')
+                finished = false;
+            break;
+        default:
+            finished = false;
+            break;
+        } // end switch(parse_state)
+        i++;
+    }
+    if (parse_state != FINISHED || i >= num_bytes_ - file_offset)
+        finished = false;
+    if (finished) {
+        res.record_length = len;
+    }
+    // if record_length is 0, no record found
+    return res;
 }
 

--- a/src/GribFile.h
+++ b/src/GribFile.h
@@ -25,6 +25,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "zuFile.h"
 
 //----------------------------------------------
+typedef struct 
+{
+    size_t file_offset;
+    size_t record_start;
+    size_t record_length;
+    int version;
+} find_record_result_t;
+    
+//----------------------------------------------
 class GribFile
 {
     public:
@@ -33,9 +42,12 @@ class GribFile
         ~GribFile ();
 
         size_t num_bytes() const {return num_bytes_;}
+        size_t num_records()  const {return num_records_;}
     
         uint8_t get(size_t idx) const;
         bool copy(uint8_t* buffer, size_t idx, size_t count) const;
+
+        find_record_result_t find_record(size_t offset) const;
     
     protected:
 
@@ -43,7 +55,8 @@ class GribFile
 
     protected:
         
-        size_t num_bytes_{0};
+        size_t num_bytes_;
+        size_t num_records_;
         uint8_t* grib_data_;
 };
 

--- a/src/GribFile.h
+++ b/src/GribFile.h
@@ -1,0 +1,54 @@
+/**********************************************************************
+XyGrib: meteorological GRIB file viewer
+
+Copyright (C) 2020 - opengrib - http://www.xygrib.org
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***********************************************************************/
+
+#ifndef GRIBFILE_H
+#define GRIBFILE_H
+
+#include <cstdint>
+
+#include "zuFile.h"
+
+//----------------------------------------------
+class GribFile
+{
+    public:
+        GribFile () = default;
+        GribFile (ZUFILE* file);
+        ~GribFile ();
+
+        size_t num_bytes() const {return num_bytes_;}
+    
+        uint8_t get(size_t idx) const;
+        bool copy(uint8_t* buffer, size_t idx, size_t count) const;
+    
+    protected:
+
+        bool retrieve(ZUFILE *f);
+
+    protected:
+        
+        size_t num_bytes_{0};
+        uint8_t* grib_data_;
+};
+
+
+#endif
+
+
+

--- a/src/GribPlot.cpp
+++ b/src/GribPlot.cpp
@@ -51,7 +51,7 @@ void GribPlot::initNewGribPlot(bool interpolateValues, bool windArrowsOnGribGrid
 	this->drawCurrentArrowsOnGrid = currentArrowsOnGribGrid;
 }
 //----------------------------------------------------
-void GribPlot::loadGrib (LongTaskProgress * taskProgress, int nbrecs)
+void GribPlot::loadGrib (LongTaskProgress * taskProgress)
 {
 	listDates.clear();
     
@@ -66,7 +66,7 @@ void GribPlot::loadGrib (LongTaskProgress * taskProgress, int nbrecs)
 	    QObject::connect(taskProgress,   &LongTaskProgress::canceled,
 	    		gribReader, &LongTaskMessage::cancel);
     }
-    gribReader->openFile (fileName, nbrecs);
+    gribReader->openFile (fileName);
     if (gribReader->isOk())
     {
         listDates = gribReader->getListDates();
@@ -74,12 +74,12 @@ void GribPlot::loadGrib (LongTaskProgress * taskProgress, int nbrecs)
     }
 }
 //----------------------------------------------------
-void GribPlot::loadFile (const QString &fileName, LongTaskProgress * taskProgress, int nbrecs)
+void GribPlot::loadFile (const QString &fileName, LongTaskProgress * taskProgress)
 {
 	this->fileName = fileName;
     delete gribReader;
 	gribReader = new GribReader ();
-	loadGrib(taskProgress, nbrecs);
+	loadGrib(taskProgress);
 	if (isReaderOk())
 		return;
 }

--- a/src/GribPlot.h
+++ b/src/GribPlot.h
@@ -40,7 +40,7 @@ class GribPlot : public RegularGridPlot
         virtual ~GribPlot ();
         
 		virtual void  loadFile (const QString &fileName,
-						LongTaskProgress *taskProgress=NULL, int nbrecs=0);
+						LongTaskProgress *taskProgress=NULL);
 		
         GribReader *getReader()  const  {return gribReader != nullptr && gribReader->isOk()? gribReader: nullptr;}
 
@@ -83,7 +83,7 @@ class GribPlot : public RegularGridPlot
 						QPainter &pnt, const Projection *proj );
     
     protected:
-		void  loadGrib (LongTaskProgress *taskProgress, int nbrecs);
+		void  loadGrib (LongTaskProgress *taskProgress);
 
         void       	initNewGribPlot (
 						bool interpolateValues=true, 

--- a/src/GribReader.h
+++ b/src/GribReader.h
@@ -117,8 +117,6 @@ class GribReader : public RegularGridReader, public LongTaskMessage
         bool checkAndStoreRecordInMap (std::shared_ptr<GribRecord> rec);
         bool storeRecordInMap (std::shared_ptr<GribRecord> rec);
 		void readGribFileContent ();
-        void processGribFileContent ();
-		bool readGrib2Record(int id, g2int lgrib);
 
 		std::vector<std::shared_ptr<GribRecord>> * getListOfGribRecords (DataCode dtc);
         int	   dewpointDataStatus;

--- a/src/GribReader.h
+++ b/src/GribReader.h
@@ -114,11 +114,9 @@ class GribReader : public RegularGridReader, public LongTaskMessage
 				ZUFILE *lugb, g2int iseek, g2int mseek, g2int *lskip, g2int *lgrib);
 		
     private:
-        bool checkAndStoreRecordInMap (GribRecord *rec);
-        bool storeRecordInMap (GribRecord *rec);
+        bool checkAndStoreRecordInMap (std::shared_ptr<GribRecord> rec);
+        bool storeRecordInMap (std::shared_ptr<GribRecord> rec);
 		void readGribFileContent (int nbrecs);
-		bool readGribRecord(int id);
-		//bool readGrib2Record(int id);
 		bool readGrib2Record(int id, g2int lgrib);
 
 		std::vector<std::shared_ptr<GribRecord>> * getListOfGribRecords (DataCode dtc);

--- a/src/GribReader.h
+++ b/src/GribReader.h
@@ -42,7 +42,7 @@ class GribReader : public RegularGridReader, public LongTaskMessage
         GribReader ();
         ~GribReader ();
 		
-        void  openFile (const QString &fname, int nbrecs);
+        void  openFile (const QString &fname);
 		
 		virtual FileDataType getReaderFileDataType () 
 					{return DATATYPE_GRIB;};
@@ -99,10 +99,10 @@ class GribReader : public RegularGridReader, public LongTaskMessage
 		void   interpolateMissingRecords (DataCode dtc);
 		void   removeInterpolateRecords ();
 
-		int countGribRecords (ZUFILE *f);
-
 	protected:
         ZUFILE *file;
+        GribFile *gfile;
+    
         void clean_vector(std::vector<GribRecord *> &ls);
         void clean_all_vectors();
         void createListDates ();
@@ -116,7 +116,8 @@ class GribReader : public RegularGridReader, public LongTaskMessage
     private:
         bool checkAndStoreRecordInMap (std::shared_ptr<GribRecord> rec);
         bool storeRecordInMap (std::shared_ptr<GribRecord> rec);
-		void readGribFileContent (int nbrecs);
+		void readGribFileContent ();
+        void processGribFileContent ();
 		bool readGrib2Record(int id, g2int lgrib);
 
 		std::vector<std::shared_ptr<GribRecord>> * getListOfGribRecords (DataCode dtc);
@@ -126,7 +127,7 @@ class GribReader : public RegularGridReader, public LongTaskMessage
 		
         std::map <uint64_t, std::vector<std::shared_ptr<GribRecord>>* >  mapGribRecords;
 
-        void   openFilePriv (const QString& fname, int nbrecs);
+        void   openFilePriv (const QString& fname);
         
         std::vector<std::shared_ptr<GribRecord>> *  getFirstNonEmptyList();
 		

--- a/src/GribRecordBuffer.cpp
+++ b/src/GribRecordBuffer.cpp
@@ -21,13 +21,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "GribFile.h"
 
 GribRecordBuffer::GribRecordBuffer (GribFile* file, size_t iseek)
-    : file_offset_(iseek), record_start_(0), record_length_(0),
-      version_(0), file_(file)
+    : file_offset_(iseek), record_start_(0), file_(file)
 {
-    if (!find_length())
+    find_record_result_t res = file->find_record(iseek);
+    if (res.record_length == 0)
     {
         version_ = 0;
         record_length_ = 0;
+    } else {
+        record_start_ = res.record_start;
+        record_length_ = res.record_length;
+        version_ = res.version;
     }
 }
 
@@ -40,102 +44,8 @@ uint8_t GribRecordBuffer::get(size_t idx) const
 
 bool GribRecordBuffer::copy(uint8_t* buffer, size_t idx, size_t count) const
 {
-    if (idx + count >= record_length_)
+    if (idx + count > record_length_)
         return false;
     return file_->copy(buffer, idx + file_offset_, count);
 }
 
-enum parse_state_t {
-    START, G, R, I, B, LEN1, LEN2, LEN3, V, V2LEN1, V2LEN2, V2LEN3, V2LEN4, SEEKEND, FINISHED
-};
-
-bool GribRecordBuffer::find_length()
-{
-    bool finished = true;
-    uint32_t len = 0;
-    size_t skip = 0;
-    size_t i = 0;
-    enum parse_state_t parse_state = START;
-    while (parse_state != FINISHED && i <= file_->num_bytes() - file_offset_) {
-        uint8_t ch = file_->get(i + file_offset_);
-        switch (parse_state) {
-        case START:
-            if (ch == 'G') {
-                parse_state = G;
-                record_start_ = i;
-            }
-            break;
-        case G:
-            parse_state = ch == 'R' ? R : START;
-            break;
-        case R:
-            parse_state = ch == 'I' ? I : START;
-            break;
-        case I:
-            parse_state = ch == 'B' ? B : START;
-            break;
-        case B:
-            len = ch << 16;
-            parse_state = LEN1;
-            break;
-        case LEN1:
-            len += ch << 8;
-            parse_state = LEN2;
-            break;
-        case LEN2:
-            len += ch;
-            parse_state = LEN3;
-            break;
-        case LEN3:
-            version_ = ch;
-            parse_state = V;
-            break;
-        case V:
-            if (version_ == 1) {
-                parse_state = SEEKEND;
-            }
-            else {
-                if (version_ == 2) {
-                    skip = 0;
-                    parse_state = V2LEN1;
-                }
-                else
-                    parse_state = START;
-            }
-            break;
-        case V2LEN1:
-            if (++skip == 5) {
-                len = ch << 24;
-                parse_state = V2LEN2;
-            }
-            break;
-        case V2LEN2:
-            len += ch << 16;
-            parse_state = V2LEN3;
-            break;
-        case V2LEN3:
-            len += ch << 8;
-            parse_state = V2LEN4;
-            break;
-        case V2LEN4:
-            len += ch;
-            parse_state = SEEKEND;
-            break;
-        case SEEKEND:
-            uint8_t eor[4];
-            parse_state = FINISHED;
-            if (!file_->copy(eor, file_offset_ + record_start_ + len - 4, 4)
-                || eor[0] != '7' || eor[1] != '7' || eor[2] != '7' || eor[3] != '7')
-                finished = false;
-            break;
-        default:
-            finished = false;
-            break;
-        } // end switch(parse_state)
-        i++;
-    }
-    if (parse_state != FINISHED || i >= file_->num_bytes() - file_offset_)
-        finished = false;
-    record_length_ = len;
-    return finished;
-}

--- a/src/GribRecordBuffer.cpp
+++ b/src/GribRecordBuffer.cpp
@@ -1,0 +1,141 @@
+/**********************************************************************
+XyGrib: meteorological GRIB file viewer
+
+Copyright (C) 2020 - opengrib - http://www.xygrib.org
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***********************************************************************/
+
+#include "GribRecordBuffer.h"
+#include "GribFile.h"
+
+GribRecordBuffer::GribRecordBuffer (GribFile* file, size_t iseek)
+    : file_offset_(iseek), record_start_(0), record_length_(0),
+      version_(0), file_(file)
+{
+    if (!find_length())
+    {
+        version_ = 0;
+        record_length_ = 0;
+    }
+}
+
+uint8_t GribRecordBuffer::get(size_t idx) const
+{
+    if (idx >= record_length_)
+        return 0;
+    return file_->get(idx + file_offset_);
+}
+
+bool GribRecordBuffer::copy(uint8_t* buffer, size_t idx, size_t count) const
+{
+    if (idx + count >= record_length_)
+        return false;
+    return file_->copy(buffer, idx + file_offset_, count);
+}
+
+enum parse_state_t {
+    START, G, R, I, B, LEN1, LEN2, LEN3, V, V2LEN1, V2LEN2, V2LEN3, V2LEN4, SEEKEND, FINISHED
+};
+
+bool GribRecordBuffer::find_length()
+{
+    bool finished = true;
+    uint32_t len = 0;
+    size_t skip = 0;
+    size_t i = 0;
+    enum parse_state_t parse_state = START;
+    while (parse_state != FINISHED && i <= file_->num_bytes() - file_offset_) {
+        uint8_t ch = file_->get(i + file_offset_);
+        switch (parse_state) {
+        case START:
+            if (ch == 'G') {
+                parse_state = G;
+                record_start_ = i;
+            }
+            break;
+        case G:
+            parse_state = ch == 'R' ? R : START;
+            break;
+        case R:
+            parse_state = ch == 'I' ? I : START;
+            break;
+        case I:
+            parse_state = ch == 'B' ? B : START;
+            break;
+        case B:
+            len = ch << 16;
+            parse_state = LEN1;
+            break;
+        case LEN1:
+            len += ch << 8;
+            parse_state = LEN2;
+            break;
+        case LEN2:
+            len += ch;
+            parse_state = LEN3;
+            break;
+        case LEN3:
+            version_ = ch;
+            parse_state = V;
+            break;
+        case V:
+            if (version_ == 1) {
+                parse_state = SEEKEND;
+            }
+            else {
+                if (version_ == 2) {
+                    skip = 0;
+                    parse_state = V2LEN1;
+                }
+                else
+                    parse_state = START;
+            }
+            break;
+        case V2LEN1:
+            if (++skip == 5) {
+                len = ch << 24;
+                parse_state = V2LEN2;
+            }
+            break;
+        case V2LEN2:
+            len += ch << 16;
+            parse_state = V2LEN3;
+            break;
+        case V2LEN3:
+            len += ch << 8;
+            parse_state = V2LEN4;
+            break;
+        case V2LEN4:
+            len += ch;
+            parse_state = SEEKEND;
+            break;
+        case SEEKEND:
+            uint8_t eor[4];
+            parse_state = FINISHED;
+            if (!file_->copy(eor, file_offset_ + record_start_ + len - 4, 4)
+                || eor[0] != '7' || eor[1] != '7' || eor[2] != '7' || eor[3] != '7')
+                finished = false;
+            break;
+        default:
+            finished = false;
+            break;
+        } // end switch(parse_state)
+        i++;
+    }
+    if (parse_state != FINISHED || i >= file_->num_bytes() - file_offset_)
+        finished = false;
+    record_length_ = len;
+    return finished;
+}

--- a/src/GribRecordBuffer.h
+++ b/src/GribRecordBuffer.h
@@ -42,10 +42,6 @@ class GribRecordBuffer
         bool copy(uint8_t* buffer, size_t idx, size_t count) const;
     
     protected:
-
-        bool find_length();
-
-    protected:
         
         size_t file_offset_;
         size_t record_start_;

--- a/src/GribRecordBuffer.h
+++ b/src/GribRecordBuffer.h
@@ -1,0 +1,62 @@
+/**********************************************************************
+XyGrib: meteorological GRIB file viewer
+
+Copyright (C) 2020 - opengrib - http://www.xygrib.org
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***********************************************************************/
+
+#ifndef GRIBRECORDBUFFER_H
+#define GRIBRECORDBUFFER_H
+
+#include <cstddef>
+#include <cstdint>
+
+class GribFile;
+
+//----------------------------------------------
+class GribRecordBuffer
+{
+    public:
+        GribRecordBuffer () = default;
+        GribRecordBuffer (GribFile* file, size_t iseek);
+        ~GribRecordBuffer () = default;
+
+        size_t file_offset() const {return file_offset_;}
+        size_t record_start() const {return record_start_;}
+        size_t record_length() const {return record_length_;}
+        uint8_t version() const {return version_;}
+    
+        uint8_t get(size_t idx) const;
+        bool copy(uint8_t* buffer, size_t idx, size_t count) const;
+    
+    protected:
+
+        bool find_length();
+
+    protected:
+        
+        size_t file_offset_;
+        size_t record_start_;
+        size_t record_length_{0};
+        uint8_t version_{0};
+        GribFile* file_;
+    
+};
+
+
+#endif
+
+
+

--- a/src/GribRecordTask.cpp
+++ b/src/GribRecordTask.cpp
@@ -1,0 +1,117 @@
+/**********************************************************************
+XyGrib: meteorological GRIB file viewer
+
+Copyright (C) 2020 - opengrib - http://www.xygrib.org
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***********************************************************************/
+
+#include "GribRecordTask.h"
+
+extern "C" {
+    #include "grib2.h"
+}
+    
+GribRecordTask::GribRecordTask ()
+    : id_(0), buffer_(nullptr), v1record_(nullptr), finished_(false), stop_(true)
+{
+}
+
+GribRecordTask::GribRecordTask (int id, GribRecordBuffer *buffer)
+    : id_(id), buffer_(buffer), v1record_(nullptr), finished_(false), stop_(false)
+{
+    // does nothing else
+}
+
+GribRecordTask::~GribRecordTask()
+{
+    delete buffer_;
+    v1record_.reset();
+    for (size_t i=0; i<v2records_.size(); i++)
+        v2records_[i].reset();
+}
+
+void GribRecordTask::run()
+{
+    if (!stop_ && buffer_ && buffer_->version() == 1) {
+        v1record_ = std::shared_ptr<GribRecord>(new GribRecord(buffer_, id_));
+        if (!v1record_->isOk()) {
+            v1record_.reset();
+        }
+    } else if (!stop_ && buffer_ && buffer_->version() == 2) {
+        readGrib2Record();
+    }
+    finished_ = true;
+}
+
+//---------------------------------------------------------------------------------
+bool GribRecordTask::readGrib2Record()
+{
+	int idrec=0;
+
+	uint8_t *cgrib = new uint8_t[buffer_->record_length()];
+    if (cgrib == nullptr || !buffer_->copy(cgrib, 0, buffer_->record_length()))
+		return false;
+
+    g2int numfields = 0;
+	g2int numlocal = 0;
+    g2int listsec0[3],listsec1[13];
+    int ierr = g2_info (cgrib,listsec0,listsec1,&numfields,&numlocal);
+    if (ierr == 0) {
+        // analyse values returned by g2_info
+        // added by david to handle discipling
+        int discipline = listsec0[0];
+        
+        int idCenter = listsec1[0];
+        int refyear  = listsec1[5];
+        int refmonth = listsec1[6];
+        int refday   = listsec1[7];
+        int refhour  = listsec1[8];
+        int refminute= listsec1[9];
+        int refsecond= listsec1[10];
+        time_t refDate = DataRecordAbstract::UTC_mktime
+            (refyear,refmonth,refday,refhour,refminute,refsecond);
+        // 				idModel
+        // 				idGrid
+        // extract fields
+        for (g2int n=0; n<numfields; n++) {
+            gribfield  *gfld = nullptr;
+            int unpack = 1;
+            g2int expand = 1;
+            ierr = g2_getfld (cgrib, n+1, unpack, expand, &gfld);
+            if (ierr == 0) {
+                idrec++;
+                //DBG("LOAD FIELD idrec=%d/%d field=%ld/%ld numlocal=%ld",idrec,nbrecs, n+1,numfields, numlocal);
+                auto rec = std::shared_ptr<Grib2Record>(
+                    new Grib2Record (gfld, idrec, idCenter, refDate, discipline));
+                if (!rec->isOk())
+                    rec.reset();
+                else
+                    v2records_.push_back(rec);
+                // if (rec->isOk() && checkAndStoreRecordInMap(rec)) {
+                //     //DBG("storeRecordInMap %d", rec->getId());
+                //     rec = nullptr; // release ownership
+                //     ok = true;   // at least 1 record ok
+                // }
+                // else {
+                //     delete rec;
+                // }
+            }
+            if (gfld)
+                g2_free(gfld);
+        }
+    }
+	delete [] cgrib;
+    return true;
+}

--- a/src/GribRecordTask.cpp
+++ b/src/GribRecordTask.cpp
@@ -61,8 +61,10 @@ bool GribRecordTask::readGrib2Record()
 	int idrec=0;
 
 	uint8_t *cgrib = new uint8_t[buffer_->record_length()];
-    if (cgrib == nullptr || !buffer_->copy(cgrib, 0, buffer_->record_length()))
+    if (cgrib == nullptr || !buffer_->copy(cgrib, 0, buffer_->record_length())) {
+        delete [] cgrib;
 		return false;
+    }
 
     g2int numfields = 0;
 	g2int numlocal = 0;
@@ -99,14 +101,6 @@ bool GribRecordTask::readGrib2Record()
                     rec.reset();
                 else
                     v2records_.push_back(rec);
-                // if (rec->isOk() && checkAndStoreRecordInMap(rec)) {
-                //     //DBG("storeRecordInMap %d", rec->getId());
-                //     rec = nullptr; // release ownership
-                //     ok = true;   // at least 1 record ok
-                // }
-                // else {
-                //     delete rec;
-                // }
             }
             if (gfld)
                 g2_free(gfld);

--- a/src/GribRecordTask.h
+++ b/src/GribRecordTask.h
@@ -1,0 +1,64 @@
+/**********************************************************************
+XyGrib: meteorological GRIB file viewer
+
+Copyright (C) 2020 - opengrib - http://www.xygrib.org
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***********************************************************************/
+
+#ifndef GRIBRECORDTASK_H
+#define GRIBRECORDTASK_H
+
+#include "GribRecordBuffer.h"
+#include "GribRecord.h"
+#include "Grib2Record.h"
+
+#include <QRunnable>
+#include <memory>
+#include <vector>
+
+//----------------------------------------------
+class GribRecordTask : public QRunnable
+{
+    public:
+        GribRecordTask ();
+        GribRecordTask (int id, GribRecordBuffer* buffer);
+        virtual ~GribRecordTask ();
+
+        int id() const   {return id_;}
+        bool isOk() const   {return v1record_ || v2records_.size() > 0;}
+        bool isFinished() const   {return finished_;}
+        void cancel()   {stop_=true;}
+        std::shared_ptr<GribRecord> record()   {return v1record_;}
+        std::vector<std::shared_ptr<Grib2Record> >& grib2records()  {return v2records_;}
+        
+        void run() override;
+        
+    protected:
+
+        bool readGrib2Record();
+        
+        int id_;
+        GribRecordBuffer *buffer_;
+        std::shared_ptr<GribRecord> v1record_;
+        std::vector<std::shared_ptr<Grib2Record> > v2records_;
+        bool finished_;
+        bool stop_;
+};
+
+
+#endif
+
+
+

--- a/src/GriddedPlotter.h
+++ b/src/GriddedPlotter.h
@@ -49,8 +49,7 @@ class GriddedPlotter :
 		virtual bool  isReaderOk () const = 0;
 		virtual GriddedReader *getReader () const = 0;
 		virtual void  loadFile (const QString &fileName, 
-								LongTaskProgress *taskProgress,
-								int nbrecs=0) = 0;
+								LongTaskProgress *taskProgress) = 0;
 		
 		virtual void  updateGraphicsParameters ();
 		

--- a/src/MapDrawer.cpp
+++ b/src/MapDrawer.cpp
@@ -34,6 +34,7 @@ MapDrawer::MapDrawer(std::shared_ptr<GshhsReader> gshhsReader)
 {
     imgEarth = nullptr;
     imgAll   = nullptr;
+	showWaveArrowsType = GRB_TYPE_NOT_DEFINED;
 
     gisReader = std::make_shared<GisReader>();
 

--- a/src/Terrain.cpp
+++ b/src/Terrain.cpp
@@ -683,14 +683,13 @@ FileDataType Terrain::loadMeteoDataFile (const QString& fileName, bool zoom)
 	taskProgress->continueDownload = true;
 	taskProgress->setMessage (LongTaskMessage::LTASK_OPEN_FILE);
 	taskProgress->setValue (0);
+    taskProgress->setWindowTitle (tr("Open file")+" GRIB");
+    taskProgress->setVisible (true);
 	
     GriddedPlotter  *griddedPlot_Temp = nullptr;
     //----------------------------------------------
 	if (taskProgress->continueDownload) {	// try to load a GRIB file
 		//DBGQS("try to load a GRIB file: "+fileName);
-		taskProgress->setWindowTitle (tr("Open file")+" GRIB");
-		taskProgress->setVisible (true);
-		taskProgress->setValue (0);
 		griddedPlot_Temp = new GribPlot ();
 		assert(griddedPlot_Temp);
 		griddedPlot_Temp->loadFile (fileName, taskProgress);    // GRIB file ?

--- a/src/Terrain.cpp
+++ b/src/Terrain.cpp
@@ -664,45 +664,36 @@ FileDataType Terrain::loadMeteoDataFile (const QString& fileName, bool zoom)
 	currentFileType = DATATYPE_NONE;
 	bool ok = false;
 	
-	taskProgress = new LongTaskProgress (this);
-	assert (taskProgress);
-	taskProgress->continueDownload = true;
-	
     if (griddedPlot != nullptr) {
 		delete griddedPlot;
         griddedPlot = nullptr;
 	}
-	taskProgress->setMessage (LongTaskMessage::LTASK_OPEN_FILE);
-	taskProgress->setValue (0);
     //--------------------------------------------------------
     // Ouverture du fichier
     //--------------------------------------------------------
-    int nbrecs;
-    {
-	    ZUFILE *file = zu_open (qPrintable(fileName), "rb", ZU_COMPRESS_AUTO);
-        if (file == nullptr) {
-        	erreur("Can't open file: %s", qPrintable(fileName));
-			taskProgress->setVisible (false);
-			delete taskProgress;
-            taskProgress = nullptr;
-	        return DATATYPE_NONE;
-		}
-		GribReader r;
-	    QObject::connect(taskProgress, &LongTaskProgress::canceled, &r, &LongTaskMessage::cancel);
-		nbrecs = r.countGribRecords (file);
-		zu_close(file);
-	}
+    ZUFILE *file = zu_open (qPrintable(fileName), "rb", ZU_COMPRESS_AUTO);
+    if (file == nullptr) {
+        erreur("Can't open file: %s", qPrintable(fileName));
+        return DATATYPE_NONE;
+    }
+    zu_close(file);
 
-    //----------------------------------------------
+	taskProgress = new LongTaskProgress (this);
+	assert (taskProgress);
+	taskProgress->continueDownload = true;
+	taskProgress->setMessage (LongTaskMessage::LTASK_OPEN_FILE);
+	taskProgress->setValue (0);
+	
     GriddedPlotter  *griddedPlot_Temp = nullptr;
-	if (nbrecs>0 && !ok && taskProgress->continueDownload) {	// try to load a GRIB file
+    //----------------------------------------------
+	if (taskProgress->continueDownload) {	// try to load a GRIB file
 		//DBGQS("try to load a GRIB file: "+fileName);
 		taskProgress->setWindowTitle (tr("Open file")+" GRIB");
 		taskProgress->setVisible (true);
 		taskProgress->setValue (0);
 		griddedPlot_Temp = new GribPlot ();
 		assert(griddedPlot_Temp);
-		griddedPlot_Temp->loadFile (fileName, taskProgress, nbrecs);    // GRIB file ?
+		griddedPlot_Temp->loadFile (fileName, taskProgress);    // GRIB file ?
 		if (griddedPlot_Temp->isReaderOk()) {
 			currentFileType = DATATYPE_GRIB;
 			ok = true;


### PR DESCRIPTION
This is a large change. I wanted to speed up the loading of Grib files, as it took many minutes on my computer. I created a new class "GribFile", that loads the grib file into memory and also counts the records. Once that is done, a new class instance of "GribRecordBuffer" is created on each record found in the grib file. Then these instances are included in an instance of "GribRecordTask", which is a QRunnable. These are then loaded into the QThreadPool, where each is run and the resulting GribRecord or Grib2Records are collected.

The result is a substantial speedup. The grib file i was using would
take nearly 10 minutes to load. With this change it is about 2
seconds. I didn't do timing as the speedup was so large.

Finally I don't have a windows or macosx development environment, so
this was only tested on linux with ubuntu 20.04. 
