### PR TITLE
Don't try to read bz2 file as grib2 it's too slow

### DIFF
--- a/src/GribReader.cpp
+++ b/src/GribReader.cpp
@@ -416,7 +416,7 @@ bool GribReader::readGribRecord(int id)
 
     if (!rec->isOk()) {
     	delete rec;
-    	return false;
+    	return true;
 	}
 
 	eof = rec->isEof();
@@ -454,7 +454,7 @@ bool GribReader::readGrib2Record(int id, g2int lgrib)
 
 	cgrib = (unsigned char *) malloc (lgrib);
     if (cgrib == nullptr)
-		return false;
+		return true;
 
 	if (zu_read(file, cgrib, lgrib) == lgrib)
 	{
@@ -518,7 +518,15 @@ void GribReader::readGribFileContent (int nbrecs)
 
 	ok = false;
     fileSize = zu_filesize(file);
-    do {
+    if (file->type == ZU_COMPRESS_BZIP) {
+    	do{
+			if (id%4 == 1)
+				emit valueChanged ((int)(100.0*id/nbrecs));
+			id ++;
+			end = readGribRecord(id);
+		} while (continueDownload && !end);
+    }
+    else do {
 		int version = seekgb_zu (file, iseek, 64*1024, &lskip, &lgrib);
 		if (id%4 == 1)
 			emit valueChanged ((int)(100.0*id/nbrecs));


### PR DESCRIPTION
Hi,

Temporary workaround for slow bz2 compressed grib1 file.

Bzip2 backward seek is very slow because it has to re-open the file and decompress it again
from the start. Our grib2 decoder seek backward...

A proper solution would be to not seek backward, we already decompressed file twice , first in  Terrain::loadMeteoDataFile and it the decoder so it shouldn't be too hard.

Regards
Didier
  