### PR TITLE
fix Accumulation time range, put period in minutes back

### DIFF
--- a/src/Grib2Record.cpp
+++ b/src/Grib2Record.cpp
@@ -403,6 +403,12 @@ void Grib2Record::analyseProductDefinitionTemplate (gribfield  *gfld)
             periodP2 = periodP1 + gfld->ipdtmpl[26] *unit_of_time_range(gfld->ipdtmpl[25])/3600; // time_length
             resosec = 3600;
         }
+        else if (unit_of_time_range(gfld->ipdtmpl[25]) == 60 && gfld->ipdtmpl[8] % 60 == 0 &&  gfld->ipdtmpl[26] % 60 == 0) {
+            periodP1 = gfld->ipdtmpl[8] /60;
+            periodP2 = periodP1 + gfld->ipdtmpl[26] /60; // time_length
+            resosec = 3660;
+        }
+
         else {
             DBG("Can't determine forecast date");
             ok = false;


### PR DESCRIPTION
Hi

this is a regression ICON precipitation and gust aren't displayed anymore, but as long accumulation period are in hours  we can use them even if the unit is in minutes.
introduced by commit 115f8e1cf2

Regards
Didier