### PR TITLE
New MeteoFrance definition

### DIFF
--- a/src/Grib2Record.cpp
+++ b/src/Grib2Record.cpp
@@ -716,6 +716,8 @@ int Grib2Record::analyseProductType ()
 				return GRB_PRECIP_TOT;
 			else if (paramnumber==49)
 				return GRB_PRECIP_TOT;
+			else if (paramnumber==65)
+				return GRB_PRECIP_TOT;
 			else if (paramnumber==52) {
 				/*
 				   cf

--- a/src/GribRecord.cpp
+++ b/src/GribRecord.cpp
@@ -101,7 +101,8 @@ void  GribRecord::translateDataType ()
     //------------------------
     // Meteo France Arome/Arpege
     //------------------------
-    else if (idCenter==84 && (idModel==204 || idModel==121 || idModel==211) && idGrid==255) {
+    else if ((idCenter==84 || idCenter==85)
+       && (idModel==204 || idModel==121 || idModel==211) && idGrid==255) {
 
 		if ( (getDataType()==GRB_PRESSURE)
 			&& getLevelType()==LV_MSL


### PR DESCRIPTION


MeteoFrance has slightly changed its models definition and Xygrib doesn't display cloud coverage anymore.
Moreover some data aren't downloaded but it's a server issue.

Sorry in french only:
Météo France a fait évoluer ce mercredi 26 janvier 2022 à compter du run de 12h les packages DCPC NWP que vous pouvez récupérer soit directement sur notre site dédié aux données publiques, soit via un abonnement Premium.

La modification est technique, et d'ampleur limitée : à présent les données sont extraites directement en GRIB2 de nos bases amont.

 On rappelle que cette modification a un impact sur les clés de certains paramètres, et certaines de ces clés sont modifiées (parameterNumber, Discipline et Category).
Les autres caractéristiques des fichiers DCPC NWP restent en l'état :

    il n'y a aucune modification fonctionnelle prévue (pas d'élargissement de domaine, ajout de paramètre ou d'échéances),
    Il n'y a aucune modification technique complémentaire (les fichiers restent en GRIB édition 2, en compression grid_jpeg).

 De nouvelles tables de définition GRIB2 ont mises à disposition (cf lien sur les pages AROME, AROME OM et ARPEGE)
